### PR TITLE
Add search visibility gating and mobile token client

### DIFF
--- a/Academy/AGENTS.md
+++ b/Academy/AGENTS.md
@@ -1335,7 +1335,7 @@ server {
 76. [x] **Section 8.1 – Search Engine Setup:** Configure Meilisearch clusters, synonyms, and ranking rules. (Functionality grade [100]/100% | Integration grade [100]/100% | UI:UX grade [100]/100% | Security grade [100]/100%)
 77. [x] **Section 8.2 – Ingestion & Sync:** Build indexing jobs and change data capture. (Functionality grade [100]/100% | Integration grade [100]/100% | UI:UX grade [100]/100% | Security grade [100]/100%)
 78. [x] **Section 8.3 – Query UX:** Implement filters, facets, typeahead, and highlights. (Functionality grade [100]/100% | Integration grade [100]/100% | UI:UX grade [100]/100% | Security grade [100]/100%)
-79. [ ] **Section 8.4 – Permissions & Privacy:** Enforce access control on search results. (Functionality grade [    ]/100% | Integration grade [    ]/100% | UI:UX grade [    ]/100% | Security grade [    ]/100%)
+79. [ ] **Section 8.4 – Permissions & Privacy:** Enforce access control on search results. (Functionality grade [45]/100% | Integration grade [40]/100% | UI:UX grade [15]/100% | Security grade [60]/100%)
 80. [ ] **Section 8.5 – Admin Search Tools:** Build audit search, spam sweeps, and saved search alerts. (Functionality grade [    ]/100% | Integration grade [    ]/100% | UI:UX grade [    ]/100% | Security grade [    ]/100%)
 81. [ ] **Section 9.1 – Messaging Templates:** Design localized email and push templates for community events. (Functionality grade [    ]/100% | Integration grade [    ]/100% | UI:UX grade [    ]/100% | Security grade [    ]/100%)
 82. [ ] **Section 9.2 – Delivery Pipeline:** Configure notification jobs, provider integrations, and retries. (Functionality grade [    ]/100% | Integration grade [    ]/100% | UI:UX grade [    ]/100% | Security grade [    ]/100%)

--- a/Academy/Student Mobile APP/academy_lms_app/lib/features/search/data/search_visibility_api.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/features/search/data/search_visibility_api.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:academy_lms_app/constants.dart' as constants;
+import 'package:academy_lms_app/features/search/models/search_visibility_token.dart';
+import 'package:http/http.dart' as http;
+
+class SearchVisibilityApi {
+  SearchVisibilityApi({http.Client? client})
+      : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  Uri _buildUri(String path) {
+    final normalizedBase = constants.baseUrl.endsWith('/')
+        ? constants.baseUrl.substring(0, constants.baseUrl.length - 1)
+        : constants.baseUrl;
+
+    return Uri.parse('$normalizedBase$path');
+  }
+
+  Future<SearchVisibilityToken> fetchVisibilityToken({String? authToken}) async {
+    final headers = <String, String>{'Accept': 'application/json'};
+
+    if (authToken != null && authToken.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $authToken';
+    }
+
+    final response = await _client.get(
+      _buildUri('/api/v1/search/visibility-token'),
+      headers: headers,
+    );
+
+    if (response.statusCode != 200) {
+      throw http.ClientException(
+        'Failed to fetch search visibility token',
+        response.request?.url,
+      );
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final data = body['data'] as Map<String, dynamic>? ?? <String, dynamic>{};
+
+    return SearchVisibilityToken.fromJson(data);
+  }
+
+  Future<void> dispose() async {
+    _client.close();
+  }
+}

--- a/Academy/Student Mobile APP/academy_lms_app/lib/features/search/models/search_visibility_token.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/features/search/models/search_visibility_token.dart
@@ -1,0 +1,40 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class SearchVisibilityToken {
+  const SearchVisibilityToken({
+    required this.token,
+    required this.filters,
+    required this.issuedAt,
+    required this.expiresAt,
+  });
+
+  final String token;
+  final List<String> filters;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+
+  factory SearchVisibilityToken.fromJson(Map<String, dynamic> json) {
+    return SearchVisibilityToken(
+      token: json['token'] as String? ?? '',
+      filters: (json['filters'] as List<dynamic>? ?? <dynamic>[])
+          .map((dynamic entry) => entry.toString())
+          .toList(growable: false),
+      issuedAt: DateTime.tryParse(json['issued_at'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      expiresAt: DateTime.tryParse(json['expires_at'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'token': token,
+      'filters': filters,
+      'issued_at': issuedAt.toUtc().toIso8601String(),
+      'expires_at': expiresAt.toUtc().toIso8601String(),
+    };
+  }
+
+  bool get isExpired => DateTime.now().toUtc().isAfter(expiresAt.toUtc());
+}

--- a/Academy/Student Mobile APP/academy_lms_app/lib/main.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/main.dart
@@ -13,6 +13,7 @@ import 'providers/community_defaults.dart';
 import 'providers/courses.dart';
 import 'providers/misc_provider.dart';
 import 'providers/my_courses.dart';
+import 'providers/search_visibility.dart';
 import 'screens/account_remove_screen.dart';
 import 'screens/category_details.dart';
 import 'screens/course_detail.dart';
@@ -60,6 +61,14 @@ class MyApp extends StatelessWidget {
             previousMyCourses == null ? [] : previousMyCourses.items,
             previousMyCourses == null ? [] : previousMyCourses.sectionItems,
           ),
+        ),
+        ChangeNotifierProxyProvider<Auth, SearchVisibilityProvider>(
+          create: (ctx) => SearchVisibilityProvider(),
+          update: (ctx, auth, provider) {
+            final visibilityProvider = provider ?? SearchVisibilityProvider();
+            visibilityProvider.updateAuthToken(auth.token);
+            return visibilityProvider;
+          },
         ),
       ],
       child: Consumer<Auth>(

--- a/Academy/Student Mobile APP/academy_lms_app/lib/providers/search_visibility.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/providers/search_visibility.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:academy_lms_app/features/search/data/search_visibility_api.dart';
+import 'package:academy_lms_app/features/search/models/search_visibility_token.dart';
+import 'package:flutter/foundation.dart';
+
+class SearchVisibilityProvider extends ChangeNotifier {
+  SearchVisibilityProvider({SearchVisibilityApi? api})
+      : _api = api ?? SearchVisibilityApi();
+
+  final SearchVisibilityApi _api;
+  SearchVisibilityToken? _token;
+  bool _isLoading = false;
+  String? _errorMessage;
+  String? _authToken;
+
+  SearchVisibilityToken? get token => _token;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> refreshToken() async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _token = await _api.fetchVisibilityToken(authToken: _authToken);
+    } catch (error, stackTrace) {
+      _errorMessage = error.toString();
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'search_visibility_provider',
+      ));
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void updateAuthToken(String? token, {bool forceRefresh = false}) {
+    if (_authToken == token && !forceRefresh) {
+      return;
+    }
+
+    _authToken = token;
+
+    if (token == null) {
+      _token = null;
+      notifyListeners();
+      return;
+    }
+
+    unawaited(refreshToken());
+  }
+
+  @override
+  void dispose() {
+    _api.dispose();
+    super.dispose();
+  }
+}

--- a/Academy/Student Mobile APP/academy_lms_app/test/features/search/search_visibility_api_test.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/test/features/search/search_visibility_api_test.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+
+import 'package:academy_lms_app/features/search/data/search_visibility_api.dart';
+import 'package:academy_lms_app/features/search/models/search_visibility_token.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  group('SearchVisibilityApi', () {
+    test('fetchVisibilityToken parses response and forwards auth header', () async {
+      final api = SearchVisibilityApi(
+        client: MockClient((request) async {
+          expect(request.url.path, '/api/v1/search/visibility-token');
+          expect(request.headers['Accept'], 'application/json');
+          expect(request.headers['Authorization'], 'Bearer abc123');
+
+          final payload = <String, dynamic>{
+            'data': <String, dynamic>{
+              'token': 'encoded.signature',
+              'filters': <String>["visibility = 'public'"],
+              'issued_at': '2024-01-01T00:00:00Z',
+              'expires_at': '2024-01-01T01:00:00Z',
+            },
+          };
+
+          return http.Response(jsonEncode(payload), 200, headers: {
+            'content-type': 'application/json',
+          });
+        }),
+      );
+
+      const tokenValue = 'abc123';
+      final result = await api.fetchVisibilityToken(authToken: tokenValue);
+
+      expect(result, isA<SearchVisibilityToken>());
+      expect(result.token, 'encoded.signature');
+      expect(result.filters, contains("visibility = 'public'"));
+      expect(result.expiresAt.isAfter(result.issuedAt), isTrue);
+    });
+  });
+}

--- a/Academy/Web_Application/Academy-LMS/app/Domain/Search/Data/SearchVisibilityContext.php
+++ b/Academy/Web_Application/Academy-LMS/app/Domain/Search/Data/SearchVisibilityContext.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Search\Data;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Support\Arrayable;
+
+final class SearchVisibilityContext implements Arrayable
+{
+    public const CURRENT_VERSION = 1;
+
+    /**
+     * @param array<int, int> $communityIds
+     * @param array<int, int> $unrestrictedPaidCommunityIds
+     * @param array<int, int> $subscriptionTierIds
+     */
+    public function __construct(
+        public readonly ?int $userId,
+        public readonly array $communityIds,
+        public readonly array $unrestrictedPaidCommunityIds,
+        public readonly array $subscriptionTierIds,
+        public readonly bool $includePublic,
+        public readonly bool $includeCommunity,
+        public readonly bool $includePaid,
+        public readonly CarbonImmutable $issuedAt,
+        public readonly CarbonImmutable $expiresAt,
+        public readonly int $version = self::CURRENT_VERSION,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'version' => $this->version,
+            'user_id' => $this->userId,
+            'community_ids' => $this->communityIds,
+            'unrestricted_paid_community_ids' => $this->unrestrictedPaidCommunityIds,
+            'subscription_tier_ids' => $this->subscriptionTierIds,
+            'include_public' => $this->includePublic,
+            'include_community' => $this->includeCommunity,
+            'include_paid' => $this->includePaid,
+            'issued_at' => $this->issuedAt->toIso8601String(),
+            'expires_at' => $this->expiresAt->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $issuedAt = CarbonImmutable::parse($payload['issued_at'] ?? 'now');
+        $expiresAt = CarbonImmutable::parse($payload['expires_at'] ?? 'now');
+
+        return new self(
+            isset($payload['user_id']) ? (int) $payload['user_id'] : null,
+            self::normaliseIntArray($payload['community_ids'] ?? []),
+            self::normaliseIntArray($payload['unrestricted_paid_community_ids'] ?? []),
+            self::normaliseIntArray($payload['subscription_tier_ids'] ?? []),
+            (bool) ($payload['include_public'] ?? false),
+            (bool) ($payload['include_community'] ?? false),
+            (bool) ($payload['include_paid'] ?? false),
+            $issuedAt,
+            $expiresAt,
+            (int) ($payload['version'] ?? self::CURRENT_VERSION),
+        );
+    }
+
+    /**
+     * @param iterable<int, mixed> $values
+     * @return array<int, int>
+     */
+    private static function normaliseIntArray(iterable $values): array
+    {
+        $normalised = [];
+
+        foreach ($values as $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $normalised[] = (int) $value;
+        }
+
+        return array_values(array_unique($normalised));
+    }
+}
+

--- a/Academy/Web_Application/Academy-LMS/app/Domain/Search/Services/SearchVisibilityService.php
+++ b/Academy/Web_Application/Academy-LMS/app/Domain/Search/Services/SearchVisibilityService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Search\Services;
+
+use App\Domain\Communities\Models\CommunityMember;
+use App\Domain\Communities\Models\CommunityPaywallAccess;
+use App\Domain\Communities\Models\CommunitySinglePurchase;
+use App\Domain\Communities\Models\CommunitySubscription;
+use App\Domain\Communities\Models\CommunitySubscriptionTier;
+use App\Domain\Search\Data\SearchVisibilityContext;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+class SearchVisibilityService
+{
+    public function __construct(
+        private readonly ?int $tokenTtl = null
+    ) {
+    }
+
+    public function forUser(?User $user): SearchVisibilityContext
+    {
+        $now = CarbonImmutable::now();
+        $ttl = $this->tokenTtl ?? (int) config('search.visibility.ttl', 900);
+        $expiresAt = $now->addSeconds(max($ttl, 60));
+
+        if ($user === null) {
+            return new SearchVisibilityContext(
+                null,
+                [],
+                [],
+                [],
+                includePublic: true,
+                includeCommunity: false,
+                includePaid: false,
+                issuedAt: $now,
+                expiresAt: $expiresAt,
+            );
+        }
+
+        $communityIds = $this->activeMembershipCommunityIds($user);
+        [$unrestrictedPaidCommunities, $subscriptionTierIds] = $this->resolvePaidAccess($user, $communityIds, $now);
+
+        return new SearchVisibilityContext(
+            $user->getKey(),
+            $communityIds,
+            $unrestrictedPaidCommunities,
+            $subscriptionTierIds,
+            includePublic: true,
+            includeCommunity: ! empty($communityIds),
+            includePaid: ! empty($unrestrictedPaidCommunities) || ! empty($subscriptionTierIds),
+            issuedAt: $now,
+            expiresAt: $expiresAt,
+        );
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    protected function activeMembershipCommunityIds(User $user): array
+    {
+        return CommunityMember::query()
+            ->where('user_id', $user->getKey())
+            ->where('status', 'active')
+            ->pluck('community_id')
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param array<int, int> $communityIds
+     * @return array{0: array<int, int>, 1: array<int, int>}
+     */
+    protected function resolvePaidAccess(User $user, array $communityIds, CarbonImmutable $now): array
+    {
+        $unrestricted = collect();
+        $tierIds = collect();
+
+        $subscriptions = CommunitySubscription::query()
+            ->select(['community_id', 'subscription_tier_id', 'status', 'ended_at'])
+            ->where('user_id', $user->getKey())
+            ->whereIn('status', ['active', 'trialing'])
+            ->where(function ($query) use ($now) {
+                $query->whereNull('ended_at')
+                    ->orWhere('ended_at', '>', $now);
+            })
+            ->get();
+
+        foreach ($subscriptions as $subscription) {
+            $unrestricted->push((int) $subscription->community_id);
+
+            if ($subscription->subscription_tier_id !== null) {
+                $tierIds->push((int) $subscription->subscription_tier_id);
+            }
+        }
+
+        $paywallAccess = CommunityPaywallAccess::query()
+            ->select(['community_id', 'subscription_tier_id', 'access_starts_at', 'access_ends_at'])
+            ->where('user_id', $user->getKey())
+            ->where(function ($query) use ($now) {
+                $query->whereNull('access_starts_at')
+                    ->orWhere('access_starts_at', '<=', $now);
+            })
+            ->where(function ($query) use ($now) {
+                $query->whereNull('access_ends_at')
+                    ->orWhere('access_ends_at', '>', $now);
+            })
+            ->get();
+
+        foreach ($paywallAccess as $access) {
+            $unrestricted->push((int) $access->community_id);
+
+            if ($access->subscription_tier_id !== null) {
+                $tierIds->push((int) $access->subscription_tier_id);
+            }
+        }
+
+        $singlePurchases = CommunitySinglePurchase::query()
+            ->select(['community_id', 'purchasable_type', 'purchasable_id'])
+            ->where('user_id', $user->getKey())
+            ->get();
+
+        foreach ($singlePurchases as $purchase) {
+            $unrestricted->push((int) $purchase->community_id);
+
+            if ($purchase->purchasable_type === CommunitySubscriptionTier::class && $purchase->purchasable_id !== null) {
+                $tierIds->push((int) $purchase->purchasable_id);
+            }
+        }
+
+        $unrestricted = $this->uniqueIntegers($unrestricted);
+
+        if (empty($unrestricted) && ! empty($communityIds)) {
+            $unrestricted = $communityIds;
+        }
+
+        return [
+            $unrestricted,
+            $this->uniqueIntegers($tierIds),
+        ];
+    }
+
+    /**
+     * @param Collection<int, int>|array<int, int> $values
+     * @return array<int, int>
+     */
+    protected function uniqueIntegers(Collection|array $values): array
+    {
+        return collect($values)
+            ->filter(fn ($value) => $value !== null)
+            ->map(fn ($value) => (int) $value)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}
+

--- a/Academy/Web_Application/Academy-LMS/app/Domain/Search/Services/SearchVisibilityTokenService.php
+++ b/Academy/Web_Application/Academy-LMS/app/Domain/Search/Services/SearchVisibilityTokenService.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Search\Services;
+
+use App\Domain\Search\Data\SearchVisibilityContext;
+use Carbon\CarbonImmutable;
+use JsonException;
+use RuntimeException;
+
+class SearchVisibilityTokenService
+{
+    public function __construct(
+        private ?string $secret = null,
+        private readonly string $algorithm = 'sha256'
+    ) {
+    }
+
+    /**
+     * @return array{token: string, filters: array<int, string>, issued_at: string, expires_at: string}
+     */
+    public function issue(SearchVisibilityContext $context): array
+    {
+        $payload = $context->toArray();
+        $encoded = $this->encodePayload($payload);
+        $signature = $this->sign($encoded);
+
+        return [
+            'token' => sprintf('%s.%s', $encoded, $signature),
+            'filters' => $this->compileFilters($context),
+            'issued_at' => $context->issuedAt->toIso8601String(),
+            'expires_at' => $context->expiresAt->toIso8601String(),
+        ];
+    }
+
+    public function validate(string $token): SearchVisibilityContext
+    {
+        [$encoded, $signature] = $this->splitToken($token);
+
+        if (! hash_equals($this->sign($encoded), $signature)) {
+            throw new RuntimeException('Search visibility token signature mismatch.');
+        }
+
+        $payload = $this->decodePayload($encoded);
+        $context = SearchVisibilityContext::fromArray($payload);
+
+        if ($context->expiresAt->lessThanOrEqualTo(CarbonImmutable::now())) {
+            throw new RuntimeException('Search visibility token has expired.');
+        }
+
+        return $context;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function compileFilters(SearchVisibilityContext $context): array
+    {
+        $filters = [];
+
+        if ($context->includePublic) {
+            $filters[] = "visibility = 'public'";
+        }
+
+        if ($context->includeCommunity && ! empty($context->communityIds)) {
+            $filters[] = sprintf(
+                "(visibility = 'community' AND community_id IN [%s])",
+                implode(', ', $context->communityIds)
+            );
+        }
+
+        if ($context->includePaid) {
+            $paidClauses = [];
+
+            if (! empty($context->unrestrictedPaidCommunityIds)) {
+                $paidClauses[] = sprintf(
+                    'community_id IN [%s]',
+                    implode(', ', $context->unrestrictedPaidCommunityIds)
+                );
+            }
+
+            if (! empty($context->subscriptionTierIds)) {
+                $tierCommunityIds = ! empty($context->communityIds)
+                    ? $context->communityIds
+                    : $context->unrestrictedPaidCommunityIds;
+
+                $subClauses = [
+                    sprintf('paywall_tier_id IN [%s]', implode(', ', $context->subscriptionTierIds)),
+                ];
+
+                if (! empty($tierCommunityIds)) {
+                    $subClauses[] = sprintf('community_id IN [%s]', implode(', ', $tierCommunityIds));
+                }
+
+                $paidClauses[] = '(' . implode(' AND ', $subClauses) . ')';
+            }
+
+            if (empty($paidClauses) && ! empty($context->communityIds)) {
+                $paidClauses[] = sprintf('community_id IN [%s] AND paywall_tier_id IS NULL', implode(', ', $context->communityIds));
+            }
+
+            if (! empty($paidClauses)) {
+                $filters[] = sprintf(
+                    "(visibility = 'paid' AND (%s))",
+                    implode(' OR ', $paidClauses)
+                );
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    protected function encodePayload(array $payload): string
+    {
+        try {
+            $json = json_encode($payload, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Failed to encode search visibility payload.', 0, $exception);
+        }
+
+        return rtrim(strtr(base64_encode($json), '+/', '-_'), '=');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function decodePayload(string $encoded): array
+    {
+        $decoded = base64_decode(strtr($encoded, '-_', '+/'), true);
+
+        if ($decoded === false) {
+            throw new RuntimeException('Search visibility token payload could not be decoded.');
+        }
+
+        try {
+            /** @var array<string, mixed> $payload */
+            $payload = json_decode($decoded, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Search visibility token payload is invalid JSON.', 0, $exception);
+        }
+
+        return $payload;
+    }
+
+    protected function splitToken(string $token): array
+    {
+        $segments = explode('.', $token, 2);
+
+        if (count($segments) !== 2) {
+            throw new RuntimeException('Search visibility token format is invalid.');
+        }
+
+        return $segments;
+    }
+
+    protected function sign(string $encoded): string
+    {
+        $secret = $this->resolveSecret();
+        $signature = hash_hmac($this->algorithm, $encoded, $secret, false);
+
+        if ($signature === false) {
+            throw new RuntimeException('Unable to sign search visibility token.');
+        }
+
+        return $signature;
+    }
+
+    protected function resolveSecret(): string
+    {
+        if ($this->secret === null || $this->secret === '') {
+            $this->secret = (string) config('search.visibility.token_secret');
+        }
+
+        if (empty($this->secret)) {
+            throw new RuntimeException('Search visibility token secret is not configured.');
+        }
+
+        if (str_starts_with($this->secret, 'base64:')) {
+            $decoded = base64_decode(substr($this->secret, 7), true);
+            if ($decoded === false) {
+                throw new RuntimeException('Invalid base64 search visibility token secret.');
+            }
+
+            $this->secret = $decoded;
+        }
+
+        return $this->secret;
+    }
+}
+

--- a/Academy/Web_Application/Academy-LMS/app/Domain/Search/Transformers/PostSearchTransformer.php
+++ b/Academy/Web_Application/Academy-LMS/app/Domain/Search/Transformers/PostSearchTransformer.php
@@ -33,7 +33,8 @@ class PostSearchTransformer implements SearchRecordTransformer
             ],
             'topics' => $topics,
             'visibility' => Arr::get($row, 'visibility') ?? Arr::get($row, 'is_private'),
-            'is_paid' => $this->boolValue(Arr::get($row, 'is_paid')), 
+            'is_paid' => $this->boolValue(Arr::get($row, 'is_paid')),
+            'paywall_tier_id' => $this->intValue(Arr::get($row, 'paywall_tier_id')),
             'created_at' => $this->dateValue(Arr::get($row, 'created_at')),
             'engagement' => [
                 'score' => (float) (Arr::get($row, 'engagement_score') ?? 0),

--- a/Academy/Web_Application/Academy-LMS/app/Http/Controllers/Api/V1/Community/SearchAuthorizationController.php
+++ b/Academy/Web_Application/Academy-LMS/app/Http/Controllers/Api/V1/Community/SearchAuthorizationController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Community;
+
+use App\Domain\Search\Services\SearchVisibilityService;
+use App\Domain\Search\Services\SearchVisibilityTokenService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SearchAuthorizationController extends CommunityApiController
+{
+    public function __construct(
+        private readonly SearchVisibilityService $visibilityService,
+        private readonly SearchVisibilityTokenService $tokenService
+    ) {
+    }
+
+    public function token(Request $request): JsonResponse
+    {
+        $user = $request->user('sanctum') ?? $request->user();
+        $context = $this->visibilityService->forUser($user);
+        $payload = $this->tokenService->issue($context);
+
+        return $this->ok($payload);
+    }
+}
+

--- a/Academy/Web_Application/Academy-LMS/config/search.php
+++ b/Academy/Web_Application/Academy-LMS/config/search.php
@@ -101,6 +101,7 @@ return [
                     'body',
                     'author',
                     'topics',
+                    'paywall_tier_id',
                     'created_at',
                     'engagement',
                 ],
@@ -109,6 +110,7 @@ return [
                     'topics',
                     'visibility',
                     'is_paid',
+                    'paywall_tier_id',
                 ],
                 'sortableAttributes' => [
                     'created_at',
@@ -184,6 +186,11 @@ return [
                 ],
             ],
         ],
+    ],
+
+    'visibility' => [
+        'token_secret' => env('SEARCH_VISIBILITY_TOKEN_SECRET', env('APP_KEY')),
+        'ttl' => (int) env('SEARCH_VISIBILITY_TOKEN_TTL', 900),
     ],
 
     'sync' => [

--- a/Academy/Web_Application/Academy-LMS/routes/api.php
+++ b/Academy/Web_Application/Academy-LMS/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\frontend\CourseController;
 use App\Http\Controllers\ApiController;
+use App\Http\Controllers\Api\V1\Community\SearchAuthorizationController;
 
 
 /*
@@ -60,5 +61,10 @@ Route::group(['middleware', ['auth:sanctum']], function () {
     Route::get('free_course_enroll/{course_id}', [ApiController::class, 'free_course_enroll']);
 
     Route::get('cart_tools', [ApiController::class, 'cart_tools']);
+});
+
+Route::prefix('v1')->group(function () {
+    Route::get('/search/visibility-token', [SearchAuthorizationController::class, 'token'])
+        ->middleware('throttle:120,1');
 });
 

--- a/Academy/Web_Application/Academy-LMS/tests/Feature/Search/SearchVisibilityTokenTest.php
+++ b/Academy/Web_Application/Academy-LMS/tests/Feature/Search/SearchVisibilityTokenTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Search;
+
+use App\Models\Community\Community;
+use App\Models\Community\CommunityMember;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SearchVisibilityTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'search.visibility.token_secret' => 'feature-secret',
+            'search.visibility.ttl' => 300,
+        ]);
+    }
+
+    public function test_guest_can_request_public_visibility_token(): void
+    {
+        $response = $this->getJson('/api/v1/search/visibility-token');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => ['token', 'filters', 'issued_at', 'expires_at'],
+        ]);
+
+        $filters = $response->json('data.filters');
+        $this->assertContains("visibility = 'public'", $filters);
+    }
+
+    public function test_authenticated_user_receives_member_visibility(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $community = Community::query()->create([
+            'slug' => Str::slug('Delta ' . Str::random(6)),
+            'name' => 'Delta',
+            'created_by' => $user->getKey(),
+            'updated_by' => $user->getKey(),
+        ]);
+
+        CommunityMember::query()->create([
+            'community_id' => $community->getKey(),
+            'user_id' => $user->getKey(),
+            'role' => 'member',
+            'status' => 'active',
+            'joined_at' => now(),
+        ]);
+
+        $response = $this->getJson('/api/v1/search/visibility-token');
+
+        $response->assertOk();
+        $filters = $response->json('data.filters');
+
+        $this->assertNotEmpty(
+            array_filter(
+                $filters,
+                fn ($filter) => str_contains((string) $filter, (string) $community->getKey())
+            ),
+            'Expected community visibility filter to include the member community.'
+        );
+    }
+}
+

--- a/Academy/Web_Application/Academy-LMS/tests/Unit/Domain/Search/SearchVisibilityServiceTest.php
+++ b/Academy/Web_Application/Academy-LMS/tests/Unit/Domain/Search/SearchVisibilityServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Search;
+
+use App\Domain\Search\Services\SearchVisibilityService;
+use App\Domain\Search\Services\SearchVisibilityTokenService;
+use App\Models\Community\Community;
+use App\Models\Community\CommunityMember;
+use App\Models\Community\CommunityPaywallAccess;
+use App\Models\Community\CommunitySinglePurchase;
+use App\Models\Community\CommunitySubscription;
+use App\Models\Community\CommunitySubscriptionTier;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class SearchVisibilityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'search.visibility.token_secret' => 'test-secret',
+            'search.visibility.ttl' => 600,
+        ]);
+
+        app()->forgetInstance(SearchVisibilityService::class);
+        app()->forgetInstance(SearchVisibilityTokenService::class);
+    }
+
+    public function test_guest_context_allows_public_only(): void
+    {
+        $service = app(SearchVisibilityService::class);
+        $context = $service->forUser(null);
+
+        $this->assertTrue($context->includePublic);
+        $this->assertFalse($context->includeCommunity);
+        $this->assertFalse($context->includePaid);
+        $this->assertSame([], $context->communityIds);
+    }
+
+    public function test_authenticated_context_includes_membership_and_entitlements(): void
+    {
+        $user = User::factory()->create();
+
+        $community = Community::query()->create([
+            'slug' => Str::slug('Alpha ' . Str::random(6)),
+            'name' => 'Alpha',
+            'created_by' => $user->getKey(),
+            'updated_by' => $user->getKey(),
+        ]);
+
+        $tier = CommunitySubscriptionTier::query()->create([
+            'community_id' => $community->getKey(),
+            'name' => 'Pro',
+            'slug' => 'pro',
+            'currency' => 'USD',
+            'price_cents' => 1200,
+            'billing_interval' => 'monthly',
+        ]);
+
+        CommunityMember::query()->create([
+            'community_id' => $community->getKey(),
+            'user_id' => $user->getKey(),
+            'role' => 'member',
+            'status' => 'active',
+            'joined_at' => now(),
+        ]);
+
+        CommunitySubscription::query()->create([
+            'community_id' => $community->getKey(),
+            'user_id' => $user->getKey(),
+            'subscription_tier_id' => $tier->getKey(),
+            'status' => 'active',
+            'renews_at' => now()->addMonth(),
+        ]);
+
+        $secondCommunity = Community::query()->create([
+            'slug' => Str::slug('Beta ' . Str::random(6)),
+            'name' => 'Beta',
+            'created_by' => $user->getKey(),
+            'updated_by' => $user->getKey(),
+        ]);
+
+        CommunityMember::query()->create([
+            'community_id' => $secondCommunity->getKey(),
+            'user_id' => $user->getKey(),
+            'role' => 'member',
+            'status' => 'active',
+            'joined_at' => now(),
+        ]);
+
+        CommunityPaywallAccess::query()->create([
+            'community_id' => $secondCommunity->getKey(),
+            'user_id' => $user->getKey(),
+            'subscription_tier_id' => null,
+            'access_starts_at' => now()->subDay(),
+            'access_ends_at' => now()->addDay(),
+        ]);
+
+        CommunitySinglePurchase::query()->create([
+            'community_id' => $community->getKey(),
+            'user_id' => $user->getKey(),
+            'purchasable_type' => CommunitySubscriptionTier::class,
+            'purchasable_id' => $tier->getKey(),
+            'currency' => 'USD',
+            'amount_cents' => 1200,
+            'provider' => 'stripe',
+            'purchased_at' => now()->subHour(),
+        ]);
+
+        $service = app(SearchVisibilityService::class);
+        $context = $service->forUser($user);
+
+        $this->assertTrue($context->includePublic);
+        $this->assertTrue($context->includeCommunity);
+        $this->assertTrue($context->includePaid);
+        $this->assertContains($community->getKey(), $context->communityIds);
+        $this->assertContains($secondCommunity->getKey(), $context->unrestrictedPaidCommunityIds);
+        $this->assertContains($tier->getKey(), $context->subscriptionTierIds);
+
+        $tokenService = app(SearchVisibilityTokenService::class);
+        $issued = $tokenService->issue($context);
+
+        $this->assertArrayHasKey('token', $issued);
+        $this->assertNotEmpty($issued['filters']);
+
+        $validated = $tokenService->validate($issued['token']);
+        $this->assertEqualsCanonicalizing($context->communityIds, $validated->communityIds);
+        $this->assertEqualsCanonicalizing($context->subscriptionTierIds, $validated->subscriptionTierIds);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement a search visibility context and token service with signed filter payloads
- expose a `/api/v1/search/visibility-token` endpoint and update search configuration for paywall tier filters
- extend the Flutter app with a search visibility API client, provider, and unit test for fetching tokens
- record partial progress for Section 8.4 in the execution matrix

## Testing
- `php artisan test` *(fails: database connections are not available in the container)*
- `flutter test` *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da6b81503483208d03b47856ac19ad