### PR TITLE
Add comprehensive platform design and content guides

### DIFF
--- a/Academy/docs/wireframes/academy-wireframes-finalized.md
+++ b/Academy/docs/wireframes/academy-wireframes-finalized.md
@@ -1,0 +1,355 @@
+# Academy Platform Finalized Wireframes
+
+This finalized companion document provides exhaustive logic maps, state inventories, and configuration references for every wireframe across web, mobile, Firebase, and security surfaces. Each section documents the **current experience** and the **post-upgrade experience** with full option coverage, branching logic, error states, integrations, and governance hooks. Use this as the authoritative specification when implementing UI flows, settings, and backend contracts.
+
+---
+
+## 1. Web Application Wireframes (Finalized)
+
+### 1.1 Admin Dashboard Panel
+
+#### 1.1.1 Current State — Full Logic Map
+- **Entry Conditions**
+  - Authenticated user with `role in {owner, admin}`; otherwise redirect to `/login`.
+  - Session locale loaded from profile or defaults to `en`.
+- **Global Layout**
+  - **Header**: Logo (links to `/admin/dashboard`), search bar (courses, users, orders), notification bell (dropdown: system alerts, support tickets, update reminders), avatar menu (Profile, Billing, Settings, Logout), language selector (en, fr, es — triggers page reload with locale param).
+  - **Left Navigation**: Dashboard, Courses, Classrooms, Students, Instructors, Orders, Coupons, Reports, Settings, Support. Hover reveals tooltip, active item highlighted.
+  - **Keyboard Shortcuts**: `/` focuses search; `g c` jumps to Courses; `g r` to Reports.
+- **Dashboard Canvas**
+  - **KPI Tiles** (Total Students, Revenue, New Orders, Active Courses) with period dropdown (Today, 7d, 30d, Custom). Each tile toggled via settings drawer.
+  - **Latest Enrollments Table**: Paginated list (20 per page) with columns (Student, Course, Timestamp, Status). Clicking row opens enrollment detail modal.
+  - **Announcements Editor**: Rich text (bold, italic, lists, media embed). Buttons: Save Draft, Publish, Preview. Publish prompts confirmation modal with visibility scope (All users, Students only, Instructors only).
+  - **Upcoming Live Classes** widget: Source from `meetings` table; CTA "Launch" (admins) or "View details".
+- **Settings Drawer** (gear icon):
+  - Widget toggles (KPI tiles, Enrollments, Announcements, Live Classes).
+  - Default landing page (Dashboard, Reports, Courses).
+  - Data range default.
+  - Auto-refresh toggle (off by default, sets `autoRefreshInterval` to 5 min when on).
+- **Data Tables** (Courses, Students, Orders):
+  - Sorting (ascending/descending). Filtering chips (status, category, instructor).
+  - Bulk actions: Export CSV, Delete, Assign Instructor. Confirmation modal for destructive actions with reason text area.
+  - Empty state with CTA to create first record.
+- **Reports**
+  - Tabs: Sales, Enrollment, Engagement.
+  - Filters: date picker, segment dropdown (All, Course, Instructor), format selector (Line, Bar, Table).
+  - Export button triggers job; toast displays success/failure.
+- **Settings Pages**
+  - **General**: Site name, logo upload (PNG/JPG, max 2MB). Validation errors inline.
+  - **Payment**: Gateway select (PayPal, Stripe), API keys, currency, tax rate.
+  - **Email**: SMTP host, port, username, password, from name/email, test email button (modal input for recipient).
+  - **Roles**: Table of users with checkboxes (Admin, Instructor, Student). Saves on submit, no granular permissions.
+- **Error States**
+  - API failures show toast + inline message.
+  - Session timeout redirects to login with flash message.
+
+#### 1.1.2 Upgraded State — Full Logic Map
+- **Entry Conditions**
+  - Authenticated user with granular permissions. RBAC matrix resolves capabilities (dashboard.view, moderation.manage, automation.edit).
+  - Feature flags determine visibility of Beta features (e.g., AI Insights).
+- **Global Layout**
+  - **Header**: Global search with scope chips (All, Communities, Posts, People, Automations). Search results open overlay with keyboard nav.
+  - **Health Indicators**: Inline status pills (Queue, Jobs, Errors). Clicking opens observability panel with logs.
+  - **Quick Create Menu**: Dropdown (Post, Event, Automation, Tier, Announcement). Each option opens guided modal wizard with validation and preview.
+  - **Notification Center**: Supports categories (System, Moderation, Revenue, Security). Inline actions (Acknowledge, Assign, Snooze).
+- **Navigation Schema**
+  - Accordion groups: Operations, Monetization, Engagement, Governance, Developer.
+  - Each route annotated with required permissions and breadcrumbs.
+- **Overview Dashboard**
+  - KPI cards with dynamic metrics. Each card includes:
+    - Metric selector.
+    - Trend sparkline.
+    - CTA "View Report" linking to analytics module with applied filters.
+    - Alert thresholds (configurable per card).
+  - **Funnel Visualization** with interactive segments (hover reveals counts, drop-off, recommended actions).
+  - **Activity Heatmap** (weekday vs. hour). Clicking cell filters feed.
+  - **Revenue Timeline** with overlays (campaigns, pricing changes).
+  - **Cohort Retention** matrix with segmentation dropdown (plan tier, acquisition source).
+  - **Automation Timeline** listing upcoming workflows; inline toggle to pause/resume.
+  - **Health Alerts** widget summarizing incidents with severity, owner, due date.
+- **Community Detail**
+  - Tabs (Overview, Moderation, Members, Levels & Points, Paywalls & Tiers, Geo Tools, Automation, Settings, Insights, Files).
+  - Each tab includes toolbars, filters, detail panels, event logs.
+  - **Moderation**: Kanban + table hybrid, SLA timers, assignment workflow, canned responses, escalation to Security tab.
+  - **Members**: Faceted search with saved filters, segment builder, CSV import with column mapper.
+  - **Levels & Points**: Rule builder supporting triggers (post published, reply accepted, event attendance), conditions (role, tier, geo), actions (points, badge, DM).
+  - **Paywalls**: Pricing matrix, plan dependencies, lifecycle events (trial start/convert, churn reasons). Integrations with Stripe, Paddle toggles.
+  - **Geo Tools**: Map layers (communities, events, members). Privacy controls, audit log, version history.
+  - **Automation**: Visual builder (IF/THEN branches). Supports manual runs, test mode, versioning, rollback.
+  - **Settings**: Multi-level accordions (Access Control, Community Policies, Content Rules, Integrations, Notifications, Data Governance). Each field annotated with data type, validation, default.
+  - **Insights**: AI summaries, trend anomalies, recommended actions with acceptance workflow.
+- **Governance & Compliance**
+  - **Audit Timeline**: Filterable feed with export, evidence attachments, signature workflow.
+  - **Policy Center**: Manage policies (moderation, privacy). Track acknowledgements by staff. Renewals scheduled.
+  - **Maintenance Planner**: Manage update packs, hotfixes, schema migrations (ties to update lifecycle).
+- **Settings Expansion**
+  - Security (SSO, OAuth, 2FA enforcement, session rules, IP ranges, AV scanning, secrets rotation schedule).
+  - Data governance (retention policies, anonymization jobs, consent templates, data export endpoints, DSR workflow).
+  - Integrations (search engine credentials, analytics sinks, CRM connectors, webhook signing keys, queue backends, AI provider keys).
+  - Appearance (theme tokens, layout templates, custom CSS/JS with approval workflow, preview modes, publish schedule).
+- **Error Handling & Resilience**
+  - Centralized toast system with severity.
+  - Retry modals for failed automation runs.
+  - Offline detection fallback.
+  - Observability panel linking to logs and metrics.
+
+### 1.2 User Type Experiences (Web)
+
+#### 1.2.1 Current State
+- **Roles**: Instructor, Student, Guest.
+- **Instructor**
+  - Dashboard showing course KPIs, pending grading, student questions.
+  - Left nav (Dashboard, My Courses, Assignments, Messages, Earnings, Profile).
+  - Course detail pages with tabs (Overview, Curriculum, Students, Q&A).
+  - Settings modal for profile, payout, notifications (email toggles).
+- **Student**
+  - Dashboard (progress summary, quick actions, upcoming events, recommendations).
+  - Course pages with modules, progress, downloads.
+  - Settings (profile, password, notifications, marketing opt-in, timezone).
+- **Guest**
+  - Marketing landing with feature highlights, pricing, testimonials, FAQ.
+  - CTA to sign up; limited navigation.
+
+#### 1.2.2 Upgraded State
+- **Expanded Roles**: Owner, Admin, Moderator, Instructor, Member, Prospect, Analyst, Partner.
+- **Owner/Admin**
+  - Global dashboard aggregator with cross-community metrics.
+  - Task center (compliance, billing, integration alerts). Accept/assign/reschedule actions.
+  - Organization settings (profile, billing, SSO, domains, SLA windows, feature flags, sandbox environments).
+- **Moderator**
+  - Specialized moderation workspace with triage board, backlog filters, real-time updates, SLA countdown, assignment, canned responses, evidence viewer.
+  - Training mode with sample cases.
+- **Instructor**
+  - Combined course + community management (feed composer, post scheduling, event management, revenue share tracking).
+  - Analytics (engagement, response time, revenue breakdown, challenge participation).
+  - Monetization settings (bundles, upsells, cross-post to newsletter).
+- **Member (Student)**
+  - Personalized home feed with content chips, pinned announcements, recommended challenges.
+  - Rewards hub (points, badges, quests, redemption catalog).
+  - Unified messaging center (DMs, announcements, automation, support). Message filters, search, read receipts.
+  - Settings: privacy, notification matrix (channel × event), accessibility (themes, text size), device management, security (sessions, 2FA, recovery codes), data control (export, delete request).
+- **Prospect**
+  - Community teaser with interactive tier comparison, dynamic testimonials, upcoming events preview.
+  - Request invite form with progress indicator, risk assessment (spam detection), captcha.
+  - Post-submission status page with ETA, referral incentives.
+- **Analyst**
+  - Analytics workspace with dashboard builder, schedule exports, API key management, IP allowlist, SQL runner (read-only), BI connectors (Snowflake, BigQuery, Tableau).
+- **Partner**
+  - Access limited to assigned communities and monetization data. View-only analytics, lead capture exports.
+
+### 1.3 Update Pack Management (Web)
+
+#### 1.3.1 Current State
+- Manual update list (versions 1.2 – 1.8).
+- Actions per version: Download instructions modal, Upload zip (name validation), Verify checkbox, Apply button (runs script), manual backup reminder, progress indicator, completion message.
+- Settings: email notification toggle, show beta versions.
+
+#### 1.3.2 Upgraded State
+- Lifecycle manager with catalog cards, filters, dependency graph, environment scoping.
+- Version detail drawer (Overview, Change Log, Preflight Checklist, Assets, Rollback plan).
+- Guided flow: select environment → run dry run → schedule maintenance → execute (automated backup, checksum verification, extraction, migration, health checks) → post-update validation.
+- Governance: policy toggles (auto security hotfix, multi-approver), integration hooks (CI/CD, monitoring), audit timeline with signatures, rollback orchestrations.
+
+---
+
+## 2. Phone Application Wireframes (Flutter) — Finalized
+
+### 2.1 Admin Phone Experience
+
+#### 2.1.1 Current State
+- **Login Flow**
+  - Email/password, Forgot password (sends email), no MFA.
+  - Session stored via shared preferences.
+- **Dashboard**
+  - KPI cards (Students, Revenue, Orders).
+  - Tabs: Courses, Orders, Notifications, Profile.
+  - Notifications list (push + email). Swipe to archive.
+- **Courses Tab**
+  - List view, filter by status, search by name. Row tap opens detail (metrics, curriculum, students).
+- **Orders Tab**
+  - Transaction list with status, filter by date.
+- **Profile**
+  - Edit profile, change password, toggle notifications, sign out.
+
+#### 2.1.2 Upgraded State
+- **Authentication**
+  - Supports SSO, biometrics, OTP MFA, device enrollment.
+  - Session scope selection (Prod, Staging, Dev).
+- **Admin Home**
+  - Real-time metrics (DAU/WAU/MAU, revenue, churn, queue size).
+  - Alerts center with severity and assignment.
+  - Quick actions (Approve member, Resolve flag, Schedule automation, Launch update).
+  - Offline indicator, sync banner.
+- **Navigation**
+  - Bottom tabs: Overview, Communities, Moderation, Automations, Settings.
+- **Communities Tab**
+  - Cards with metrics, sync status, quick links (View feed, Members, Paywall).
+  - Detail view replicates desktop tabs optimized for mobile (swipe between sections).
+- **Moderation Tab**
+  - Queue list with filters (severity, SLA, assigned to me).
+  - Item detail: content, context, actions (approve, hide, warn, ban, escalate). Quick templates, policy references.
+  - Batch actions via multi-select.
+- **Automations**
+  - Workflow list (status, next run). Create/edit wizard with conditions, actions, testing (simulate input, preview outputs), scheduling.
+- **Settings**
+  - Account (profile, security, devices, notifications).
+  - Organization (policies, tiers, integrations, update management).
+  - Support (contact, run diagnostics, submit feedback).
+  - Dark mode toggle, accessibility options (text size, high contrast).
+- **Error & Offline Handling**
+  - Local cache, queue actions, conflict resolution modals.
+  - Diagnostics log export.
+
+### 2.2 User Phone Experience
+
+#### 2.2.1 Current State
+- **Roles**: Student.
+- **Flows**
+  - Onboarding slides, login, registration.
+  - Home dashboard with enrolled courses, recommended content.
+  - Course detail with lessons, downloads, quizzes.
+  - Notifications center (course updates).
+  - Profile & settings (notifications, downloads, logout).
+
+#### 2.2.2 Upgraded State
+- **Roles**: Member, Moderator, Instructor, Prospect.
+- **Onboarding**
+  - Adaptive journey by role (select persona, join codes, invite acceptance).
+  - Consent screens (privacy, notifications, data use).
+- **Home**
+  - Personalized feed (posts, events, challenges). Filter chips, infinite scroll, reactions, comments, share.
+  - Quick actions (Create post, Join live event, Redeem reward).
+  - Leaderboard preview, upcoming events, quests.
+- **Community View**
+  - Tabs: Feed, Events, Members, Resources, Rewards.
+  - Top-level actions vary by role (moderation queue for moderators, insights for instructors).
+- **Messages**
+  - Unified inbox (DMs, group chats, announcements). Search, pinned, mute threads, attachments, voice notes, reactions.
+- **Events**
+  - Calendar view, RSVP, add to calendar, join streaming, event chat, replay.
+- **Rewards & Progress**
+  - Points history, badges, quests, redemption catalog (gift cards, perks).
+- **Settings**
+  - Notification matrix (channel vs. event), privacy controls, security (2FA, devices, passkeys), accessibility (font, colors, animations), data (download, delete request), payment methods, subscription management.
+- **Offline/Sync**
+  - Content caching, background sync, conflict resolution, push resubscription.
+
+---
+
+## 3. Firebase Wireframes (Finalized)
+
+### 3.1 Current State
+- **Projects**: Single project with default app (`academy-mobile`), limited environments (prod only).
+- **Authentication**: Email/password, Google provider, no custom claims.
+- **Firestore**: Collections `users`, `courses`, `enrollments`, `messages`. Rules allow authenticated read/write with coarse checks.
+- **Storage**: Bucket for course assets; simple path rules (`/courses/{courseId}/media`).
+- **Functions**: Minimal HTTP triggers for notifications.
+- **Analytics**: Default events (session_start, screen_view).
+- **Remote Config**: Not utilized.
+- **Monitoring**: Crashlytics enabled, no alert routing.
+
+### 3.2 Upgraded State
+- **Project Structure**
+  - Separate projects (Dev, Staging, Prod) with shared config via `firebase.json`. IAM roles per environment.
+  - Naming convention: `academy-{env}-{region}`.
+- **Authentication**
+  - Providers: Email/password, OAuth (Google, Apple, Microsoft), SAML, phone.
+  - MFA enforcement for admins/moderators.
+  - Custom claims (role, tier, feature flags, beta access, compliance status).
+  - Session management (revocation, device metadata).
+- **Firestore**
+  - Collections: `communities`, `posts`, `comments`, `members`, `events`, `automation_runs`, `audit_logs`, `reward_catalog`, `moderation_queue`.
+  - Document schema tables with fields, types, indexes (composite, array). Partitioning by community.
+  - Security rules with granular checks (role-based, community membership, content visibility, paywall enforcement). Tests in Firebase Emulator Suite.
+  - Automated backups & PITR configuration.
+- **Storage**
+  - Buckets per environment with lifecycle policies, signed URL enforcement, AV scan integration via Functions.
+  - Metadata tags (communityId, role, visibility).
+- **Cloud Functions**
+  - Modules: moderation actions, automation workflows, analytics events, Stripe webhooks, push notifications, geo updates.
+  - CI/CD deploy pipeline with canary releases, observability (Cloud Logging, Error Reporting).
+- **Analytics**
+  - Custom events (member_joined, post_published, challenge_completed, tier_upgraded, retention_checkpoint, automation_failed).
+  - Audiences, funnels, conversions mapped to business KPIs.
+- **Remote Config**
+  - Feature flags, experiment variants, personalization.
+- **Extensions & Integrations**
+  - Extensions for SendGrid email, Stripe payments, Firestore trigger analytics.
+  - BigQuery export for analytics, Data Studio dashboards.
+- **Monitoring & Alerts**
+  - Crashlytics alerts with on-call rotation.
+  - Performance Monitoring thresholds and dashboards.
+  - Security rules monitoring with anomaly detection.
+
+---
+
+## 4. Security Wireframes (Finalized)
+
+### 4.1 Current Security Center
+- **Access**
+  - Located under Admin → Settings → Security.
+  - Sections: Password policy (minimum length, complexity), session timeout (30 min default), login attempts (lockout after 5), IP blacklist manual list.
+- **Audit Logs**
+  - Basic table (user, action, timestamp). CSV export.
+- **Compliance**
+  - Links to privacy policy. Manual checkbox for GDPR consent log.
+- **Incident Response**
+  - Email support alias, no runbooks.
+- **Infrastructure**
+  - No CSP controls UI, SSL monitoring manual, webhook secrets static.
+
+### 4.2 Upgraded Security Orchestration
+- **Security Command Center Dashboard**
+  - Widgets: Posture Score, Open Incidents, MFA Coverage, Active Sessions, Update Compliance, Vulnerability Scan status.
+  - Filters: Environment (Prod, Staging, Dev), Severity, Owner.
+  - Actions: Assign incident, Trigger scan, Export report, Schedule review.
+- **Identity & Access**
+  - MFA policies per role, passwordless options (WebAuthn), device trust management (list, revoke, risk score).
+  - Session management (list active sessions, terminate, set max concurrency).
+  - API keys & service accounts management, rotation reminders, scopes.
+- **Policy Management**
+  - Policy catalog (Security, Privacy, Moderation, Data retention). Each policy has versioning, approval workflow, attestation tracking, expiration alerts.
+  - Control matrix mapping policies to controls and owners.
+- **Threat Monitoring**
+  - Real-time alerts feed (auth anomalies, AV hits, rate limit breaches, suspicious geo, DDoS signals).
+  - Integrations: SIEM (Splunk), PagerDuty, Slack.
+  - Runbook links per alert type.
+  - Evidence collection panel (attach logs, screenshots, notes).
+- **Vulnerability Management**
+  - Scans (SAST, DAST, Dependency) with status, remediation owner, SLA countdown, CVSS score, fix instructions.
+  - Exceptions workflow (request waiver, approve, review date).
+- **Update & Patch Compliance**
+  - Mirrors update pack lifecycle (applied vs. pending). Requires attestation and supporting evidence (screenshots, logs).
+- **Data Governance**
+  - DSR dashboard (access, delete, rectification). Workflow statuses, assignees, deadlines.
+  - Data retention policies per entity with timers, purge schedules, legal hold overrides.
+- **Incident Response**
+  - Playbooks (Intrusion, Data Breach, Abuse, Availability). Steps with owners, timers, communication templates.
+  - Post-incident review capture with lessons learned and action items.
+- **Audit Center**
+  - Comprehensive log explorer with filters, saved searches, export to SIEM, retention schedule, immutability settings.
+  - Evidence locker (WORM storage) with tagging, chain-of-custody.
+- **Settings**
+  - CSP builder (directives, report-only toggle, fallback sources).
+  - Security headers configuration (HSTS, COOP/COEP, referrer policy).
+  - Bot mitigation (reCAPTCHA keys, rate limit thresholds, challenge settings).
+  - Encryption controls (key rotation schedule, envelope encryption toggles, secrets vault integration).
+  - Legal (DPAs, certifications, audit logs for attestations).
+
+---
+
+## 5. Cross-Surface Traceability & Governance
+
+- **Traceability Matrix**: Each module includes requirement IDs linking to this finalized spec. Updates tracked via change log.
+- **Versioning**: Document version stored with semantic version. Change history appended at bottom.
+- **Approval Workflow**: Requires sign-off from Product, Design, Security, and Engineering leads. Status tracked in governance tool.
+- **Implementation Hooks**
+  - API contracts referenced via OpenAPI/GraphQL specs.
+  - Telemetry requirements enumerated per flow (events, properties, timing).
+  - Accessibility criteria (WCAG 2.2 AA) mapped per screen.
+
+---
+
+## 6. Change Log
+
+- **v1.0.0 (Finalized)** — Derived from existing wireframes, expanded to include exhaustive logic, settings, and governance touchpoints for each application surface, Firebase integration, and security orchestration.

--- a/Academy/docs/wireframes/academy-wireframes.md
+++ b/Academy/docs/wireframes/academy-wireframes.md
@@ -1,0 +1,315 @@
+# Academy Platform Wireframes — Current vs. Upgraded States
+
+This document captures textual wireframes and logic maps for the Academy platform across web, mobile, Firebase, and security layers. For each scope we document both the **current experience** (as-is) and the **post-upgrade experience** (to-be) with exhaustive option coverage, interaction states, and settings.
+
+---
+
+## 1. Web Application
+
+### 1.1 Admin Dashboard Panel
+
+#### 1.1.1 Current State Wireframe
+- **Global Layout**
+  - **Header Bar**: Logo (left), search box (global course/community search), notification bell (dropdown with latest alerts), profile avatar (dropdown with profile, settings, logout), language selector.
+  - **Left Navigation Rail** (icon + label): Dashboard (default landing), Courses, Classrooms, Students, Instructors, Orders, Coupons, Reports, Settings, Support.
+  - **Content Canvas**: Two-column grid.
+    - **Column A (2/3 width)**: KPI tiles (Total Students, Revenue, New Orders, Active Courses); latest enrollments list (student avatar, course name, timestamp, status pill); announcements editor (rich text box with publish/save draft buttons).
+    - **Column B (1/3 width)**: Upcoming live classes (date/time, host, CTA to join/launch), support tickets (count, link to table), quick links (Add course, Create coupon).
+- **Dashboard Settings Drawer** (modal triggered from gear icon):
+  - Toggle widgets (KPI tiles, enrollments, announcements, upcoming classes).
+  - Data range selector (Today, 7 days, 30 days, Custom).
+  - Default dashboard landing (Dashboard, Reports, Courses).
+- **Data Tables** (Courses, Students, Orders):
+  - Column headers with sort icons; filters row for status, date range, category.
+  - Row actions (view, edit, disable/archive).
+  - Bulk actions toolbar (select all, export CSV, delete, assign instructor).
+- **Reports Page**:
+  - Tabs: Sales, Enrollment, Engagement.
+  - Charts: line chart (sales by month), bar chart (course completion), pie chart (payment gateway split).
+  - Export dropdown (CSV, PDF) with date picker.
+- **Settings Section** (current scope limited):
+  - General: site name, logo upload.
+  - Payment: payment gateway keys, currency, tax rate.
+  - Email: SMTP host, port, sender name, test email button.
+  - Roles: assign admin/instructor/student checkboxes per user (no granular permissions).
+
+#### 1.1.2 Upgraded State Wireframe
+- **Global Layout Enhancements**
+  - **Header Bar**: Adds real-time health indicators (queue depth, online members), global search with scope chips (All, Communities, Posts, People), quick-create menu (post, event, automation).
+  - **Left Navigation** (grouped sections with collapsible accordions):
+    1. **Operations**: Overview, Communities, Members, Moderation Queue, Automation, Geo Tools.
+    2. **Monetization**: Paywalls & Tiers, Revenue Reports, Coupons, Stripe Dashboard link.
+    3. **Engagement**: Levels & Points, Content Scheduler, Notifications.
+    4. **Governance**: Audit Logs, Compliance, Settings.
+  - **Contextual Right Sidebar** (dynamic):
+    - Displays AI insights (retention alerts, trending content), quick filters (role, status, cohort), collaboration notes.
+- **Overview Dashboard Canvas** (three-column responsive grid):
+  - **Top Row KPI Cards**: DAU/WAU/MAU, Conversion to First Post, MRR, Churn %, Net New Members, Queue Size; each card has dropdown to change metric, hover tooltip with definition, click to drill down.
+  - **Middle Row**: Member Funnel Sankey chart, Activity Heatmap (day/hour matrix), Revenue Timeline (line + bar), Cohort Retention chart (select timeframe).
+  - **Bottom Row**: Flags summary widget (counts by severity with "Review" CTA), Scheduled Automations list (status pill, next run, toggle), Health Alerts (auto-archive triggers, error rates) with acknowledge/dismiss actions.
+- **Community Detail Page** (tabbed interface):
+  1. **Overview Tab**: At-a-glance metrics, top posts, membership trend, paywall summary, map preview of geo boundaries.
+  2. **Moderation Queue Tab**: Table with filters (type, reason, severity, reporter). Bulk actions (approve, hide, ban, escalate). Side panel preview with context, evidence attachments, policy links. Assign to moderator dropdown.
+  3. **Members Tab**: Faceted search (role chips: Owner, Admin, Moderator, Member, Guest), status filters (Active, Pending, Banned), segments (Joined <30d, High Spend, Dormant). Row actions: promote/demote, DM, ban/unban, export, add notes. Bulk invite (CSV upload wizard), merge duplicates flow.
+  4. **Levels & Points Tab**: Points rules table (trigger, base points, caps, automation triggers). Preview leaderboard (top 10). Simulate rule change modal (input scenario, preview results).
+  5. **Paywalls & Tiers Tab**: Pricing matrix (tier, price, billing cycle, benefits). Controls for trials, coupons, upgrade/downgrade rules. Stripe session log viewer. Issue comp access modal (recipient, tier, expiration, reason).
+  6. **Geo Tools Tab**: Map canvas with draw/edit polygon tools, import GeoJSON button, place list with radius settings. Privacy toggle (public vs members-only map). Audit log of geo edits.
+  7. **Automation Tab**: Workflow cards (Scheduled Posts, Welcome DM, Auto-Archive). Each card expands to show triggers, conditions, actions. Builder with drag-and-drop steps (IF new member -> wait 1 day -> send DM). Calendar view of scheduled items.
+  8. **Settings Tab**: Multi-section accordions covering join policy, visibility, moderation flags, profanity lists, media limits, join questions (custom fields with validation), webhooks (URL, secret, event types), integrations (Slack, Zapier, Salesforce), notification preferences, consent toggles, data retention policies.
+- **RBAC Management**
+  - Role matrix (Owner, Admin, Moderator, Analyst, Support). Checkbox grid for capabilities (community.manage, paywall.manage, moderation.review, analytics.view, automation.edit, geo.edit).
+  - Device trust management (list of devices, revoke buttons), 2FA enforcement toggle per role.
+- **Audit & Compliance Dashboard**
+  - Timeline feed of actions (who, what, before/after snapshot). Filters (date, role, action type).
+  - Export scheduler (CSV, JSON, WORM S3 sync status).
+- **Settings Expansion**
+  - **Security**: Password/2FA policies, OAuth providers, session length, IP allowlists, webhook signing keys, AV scanning toggles, rate limit settings, secret rotation reminders.
+  - **Data Governance**: Retention windows per entity, anonymization schedule, consent templates, data export pipelines.
+  - **Integrations**: Meilisearch endpoint configuration, analytics destinations, CRM, email providers, push keys.
+  - **Appearance**: Theme builder (colors, typography), layout presets, custom CSS/JS with approval workflow.
+
+### 1.3 Update Pack Management (Web)
+
+#### 1.3.1 Current State Wireframe
+- **Location**: Hidden under Admin → System Update → “Manual update” tab within settings.
+- **Update Pack List**: Static table sourced from bundled folders (`Web_Application/Update pack/v1.2` through `v1.8`). Columns: Version (1.2, 1.2.1, 1.2.2, 1.2.3, 1.3, 1.4, 1.5, 1.5.1, 1.6, 1.7, 1.8), Release Date (text entry), File Name (`update_1.x.zip`), Notes (textarea with pasted changelog).
+- **Actions per row**: Download instructions (opens modal with steps from `Update Instructions.txt`), Upload button (opens file picker for corresponding zip), Verify checkbox (manual confirmation after upload), Apply button (runs server-side script; currently triggers maintenance mode & runs migrations sequentially).
+- **Logic Flow**:
+  1. Admin selects target version row.
+  2. Upload step requires matching zip name; validation only checks extension.
+  3. Upon clicking Apply, modal warns about backups (manual). Progress bar shows extraction, file replace, cache clear, migration. Errors displayed inline; no rollback.
+  4. Completion screen shows “Update success” message with reminder to clear browser cache.
+- **Settings Drawer**: Toggle for email notification post-update, checkbox for “Show beta versions” (hidden by default).
+
+#### 1.3.2 Upgraded State Wireframe
+- **Location**: Admin → Governance → Platform Lifecycle → “Update Packs & Hotfixes”.
+- **Update Catalog Grid**:
+  - Cards for each release including historical packs (1.2 – 1.8) and future upgrade tracks.
+  - Card fields: Version, Release channel (Stable/Beta/Hotfix), Compatibility (current schema level), Mandatory before upgrade flag, Release notes link, Pre-check summary (files affected, database migrations, downtime estimate).
+  - Filters: channel, release year, dependency status (Required/Optional/Applied).
+- **Version Detail Drawer**:
+  - Tabs: Overview, Change Log, Preflight Checklist, Assets.
+  - Overview lists prerequisites (backup snapshot, cron pause), target environments, automation scripts.
+  - Preflight Checklist includes automated environment scan (storage write, queue worker status, maintenance window) with pass/fail icons.
+  - Assets tab surfaces download links for `update_1.x.zip`, checksum (SHA-256), signed instructions PDF, rollback scripts, docker compose overrides.
+- **Action Flow**:
+  1. Choose environment scope (Production, Staging, Dev) → toggles per environment.
+  2. Run “Dry Run” (simulated apply) capturing file diff summary and DB migration preview; output stored in audit log.
+  3. Schedule maintenance window (datetime picker, duration) with stakeholder notifications (email, Slack, in-app) and optional reminder.
+  4. Execute update: pipeline orchestrates backup snapshot, package verification via checksum, extraction to staging path, health checks, swap, DB migrations with transactional guard; errors trigger automated rollback.
+  5. Post-update validation: smoke test checklist, telemetry ping, create release note entry, prompt to tag update with notes (who, why, risk level).
+- **Settings & Governance**:
+  - Policy toggles for auto-applying security hotfixes, requiring multi-approver sign-off, enforcing staging validation before production.
+  - Integration hooks to CI/CD (GitHub Actions artifact import), cloud backups, and monitoring (Datadog status check).
+  - Audit timeline capturing each step with user, timestamp, result, logs.
+
+### 1.2 User Type Experiences (Web)
+
+#### 1.2.1 Current State Wireframes
+- **Roles Covered**: Instructor, Student, Guest (unauthenticated).
+- **Instructor Dashboard**
+  - Header with shortcuts (Create course, Live class, Messages).
+  - Left nav: Dashboard, My Courses, Assignments, Messages, Earnings, Profile.
+  - Main: Course performance cards (enrollment, completion rate), assignments needing grading, recent student questions.
+  - Settings modal: profile info, payout method, notification toggles (email for questions/orders).
+- **Student Dashboard**
+  - Hero banner with progress summary (overall completion). Quick actions (Resume course, View calendar, Join live session).
+  - Tiles: Enrolled courses (cards with progress bar and CTA), Upcoming events list, Certificates earned.
+  - Right column: Announcements, Recommended courses, Support CTA.
+  - Settings page: profile info, password change, notification toggles (email reminders, marketing opt-in).
+- **Guest Landing**
+  - Marketing hero, featured courses grid, testimonials, sign-up/login prompts.
+  - No personalization; simple footer with links.
+
+#### 1.2.2 Upgraded State Wireframes
+- **Expanded Roles**: Owner, Admin, Moderator, Instructor, Member (student), Prospect (lead), Analyst.
+- **Owner/Admin Web Experience**
+  - Entry landing shows global dashboard (mirrors admin panel with cross-community metrics), alerts for compliance tasks, tasks due, integration health.
+  - Settings hub (profile, organization profile, billing, SSO connections, domain management, feature flags).
+- **Moderator Workspace**
+  - Focused moderation queue board (Kanban columns: New, In Review, Resolved, Escalated).
+  - Context viewer (post preview, history, reporter info). Actions: apply labels, request clarification, escalate to admin, mute user (duration slider).
+  - Quick filters (community, severity, SLA timer).
+  - Settings: notification routing (email, push, Slack), working hours, substitution rules.
+- **Instructor Portal (Community-enabled)**
+  - Hybrid view combining course management and community feed.
+  - Tabs: Courses, Community Posts, Events, Analytics, Monetization (upsell packs).
+  - Course tab: same as current plus community cross-post toggle, bundling, AB test module visibility.
+  - Community tab: feed composer (post types: text, poll, challenge), quick templates, tag selection, schedule post.
+  - Analytics tab: member engagement charts, cohort analysis, question response time, revenue share dashboards.
+  - Settings: course-to-community mapping, content visibility rules, auto-responders.
+- **Member (Student) Dashboard**
+  - Personalized feed (communities joined) with filter chips (All, Courses, Challenges, Events, Announcements).
+  - Right rail: leaderboard (levels, points, badges), upcoming events calendar, recommended posts.
+  - Top nav: Feed, Courses, Messages, Events, Rewards, Settings.
+  - Messages area: unified inbox (DMs, announcements, automation messages) with read/unread states.
+  - Settings: notification matrix (email, push, in-app per event type), privacy controls (profile visibility, DM permissions), data download, device sessions, linked accounts, accessibility preferences (font size, theme).
+- **Prospect Experience**
+  - Community teaser page with sections gated behind sign-up (blurred content preview), tier comparison table, CTA to join free tier.
+  - Request invite flow (multi-step form: profile info, goals, compliance questions, captcha).
+- **Analyst Workspace**
+  - Focus on reports with ability to save dashboards, schedule exports, connect BI tools (Snowflake, BigQuery) via secure tokens.
+  - Settings: data access scopes, IP allowlist, API key management.
+
+---
+
+## 2. Phone Application (Flutter)
+
+### 2.1 Admin Phone Experience
+
+#### 2.1.1 Current State Wireframe
+- **Login Screen**: Email/password fields, "Forgot password" link, remember me toggle.
+- **Dashboard (Tabbed)**: Tabs for Overview, Orders, Students.
+  - **Overview Tab**: KPI tiles (revenue today, new enrollments), notifications list.
+  - **Orders Tab**: List with status badges, filter drawer (status, date range), detail screen (order info, refund button).
+  - **Students Tab**: Search bar, list with avatars, quick actions (call, email, view profile).
+- **Drawer Menu**: Profile, Settings (basic), Sign out.
+- **Settings Screen**: Notification toggle, currency display preference, dark mode switch.
+
+#### 2.1.2 Upgraded State Wireframe
+- **Auth Suite**
+  - Splash with brand + environment badge (dev/stage/prod).
+  - Login options: Email/Password, SSO (SAML/OAuth), Passkey/WebAuthn fallback, biometric quick login.
+  - Device enrollment screen (name device, trust toggle, view active sessions).
+- **Admin Home** (bottom navigation: Home, Communities, Moderation, Automations, More).
+  - **Home Tab**: Scrollable cards (Realtime KPIs, Alerts, Revenue trend mini-chart, Pending approvals). Quick action FAB (create announcement/post/event/automation).
+  - **Communities Tab**: Card list with key stats, filter chip row (All, Trending, Needs Attention). Tap opens detail with mini-tabs (Overview, Members, Moderation, Paywall, Settings) adapted for mobile.
+  - **Moderation Tab**: Queue list with swipe actions (approve, reject). Batch mode toggle. Detail screen with evidence gallery, comment history, action buttons (ban with duration picker, escalate, assign).
+  - **Automations Tab**: Kanban list (Scheduled, Running, Paused, Error). Each automation card opens step editor (condition > action). Inline toggle to pause/resume.
+  - **More Tab**: Access to Audit Logs, Reports, Integrations, Settings, Support.
+- **Settings (Extensive)**
+  - Account: profile, password/passkey, languages, timezone.
+  - Security: 2FA setup, device management, IP restrictions, session timeout, notification for new login.
+  - Notifications: per event type (moderation alerts, revenue, automation failures) across channels (push, email, SMS, Slack).
+  - Data: export data request, retention policy view, consent records.
+  - Integrations: configure Stripe keys, Slack webhooks, Zapier, Meilisearch endpoint (view-only), analytics destinations.
+  - Appearance: theme, font size, haptics toggle.
+
+### 2.2 User-Type Phone Experiences
+
+#### 2.2.1 Current State Wireframes
+- **Student App**
+  - Bottom nav: Home, Courses, Downloads, Profile.
+  - **Home**: Carousel (featured courses), continuing courses list, announcements card.
+  - **Courses**: Grid with filter dropdown (category, level). Course detail with description, lessons list, enroll/continue button.
+  - **Downloads**: Offline content list, storage indicator, delete button.
+  - **Profile**: Progress stats, wishlist, settings (profile info, password, notification toggle, logout).
+- **Instructor (Mobile)**
+  - Similar base app with extra tab: Manage (course list with status, create course CTA), messages inbox.
+- **Guest**
+  - Onboarding screens, sign-in/sign-up prompts, limited browse of catalog.
+
+#### 2.2.2 Upgraded State Wireframes
+- **Member (Student) App**
+  - Bottom nav: Feed, Courses, Events, Messages, Rewards.
+  - **Feed**: Stories row (challenges, announcements), feed posts (text, media, polls), reaction bar, comment preview, CTA to join tiers when encountering gated post.
+  - **Composer**: FAB with options (Post, Poll, Question, Challenge submission, Share resource). Scheduling, attach files from device/cloud.
+  - **Events**: Calendar view (month/week), list of upcoming events, RSVP controls, add to device calendar, map view for geo-enabled events.
+  - **Messages**: Tabs for Direct Messages, Channels, Automation inbox. Actions: mark unread, mute thread, escalate to support.
+  - **Rewards**: Points tally, level progress bar, badges gallery, missions list (earn points by tasks). Claim reward flow (select reward, confirm, view redemption code).
+  - **Settings**: Notification matrix, privacy (profile visibility, DM permissions, location sharing), accessibility (text size, high contrast, captions), connected services (Google, Apple, Slack), data export, delete account, session management, security (biometric lock, passcode).
+- **Moderator Mobile**
+  - Dedicated app mode accessible via role detection.
+  - Tabs: Queue, Alerts, Members, Tools.
+  - Queue: card stack UI with swipe actions, detail overlay (context, policy references, prior offenses). Bulk operations using multi-select.
+  - Alerts: system-generated alerts (spam spike, queue SLA breach) with acknowledge/resolution controls.
+  - Members: search and manage users, apply tags, view flags history, send quick messages.
+  - Tools: canned responses, resource links, escalation flow to admin.
+- **Instructor Mobile**
+  - Tabs: Feed, Courses, Insights, Monetization, Settings.
+  - Insights: charts (engagement, completion, revenue), export/share options.
+  - Monetization: manage offerings, create bundles, price edits subject to `paywall.manage` permission.
+  - Settings: community linking, automation toggles, notification preferences.
+- **Admin/Owner Mobile (non-dashboard)**
+  - Additional "Organization" section (billing overview, usage limits, seat management, feature flags) with approvals queue.
+- **Prospect (Lead) Mode**
+  - Controlled preview: limited posts (blurred), CTA to apply, tier comparison, testimonials, FAQ, compliance disclaimers.
+
+---
+
+## 3. Firebase Requirements Wireframes
+
+### 3.1 Current State
+- **Projects**: Single Firebase project per environment not fully defined; basic FCM usage for push notifications (mobile only).
+- **Services Utilized**: Cloud Messaging (limited), Analytics (not instrumented), Authentication (not integrated), Firestore/RTDB (unused).
+- **Console Navigation Wireframe**
+  - Home → Cloud Messaging: topic list (General, Promotions), device token upload CSV.
+  - Project Settings: app registration (Android/iOS), server key copy, no web app configured.
+  - No alerting/dashboard customization.
+- **Settings Coverage**
+  - API keys stored manually, no environment separation, no IAM roles beyond owner.
+
+### 3.2 Upgraded State
+- **Project Structure**
+  - Multi-project setup: `academy-dev`, `academy-staging`, `academy-prod` with App Distribution.
+  - Apps registered: Web, Android, iOS (admin + member variants) with SHA fingerprints, APNs auth keys.
+- **Services & Wireframes**
+  - **Cloud Messaging**: Topics (Announcements, Moderation, Events, Revenue Alerts, Automations). Conditional segments (role, tier, activity). Notification composer templates with localization, scheduling, A/B tests. Delivery analytics dashboard.
+  - **Authentication**: Identity provider list (Email/Password, Google, Apple, SAML via custom auth). User management view (search, disable, add custom claims for roles). MFA enforcement toggles per app.
+  - **Firestore**: Collections (notifications_queue, realtime_presence, automation_jobs). Rules viewer showing security rules per collection.
+  - **Remote Config**: Parameter groups (feature flags, UI copy, paywall experiments). Targeting (tier, platform, locale). Version history and rollback controls.
+  - **Crashlytics**: Issue list, alerts, velocity chart, linked to Slack/Email.
+  - **Performance Monitoring**: Traces dashboard, custom metrics (feed_load_time, post_publish_latency).
+  - **App Check**: Provider selection (DeviceCheck, Play Integrity, reCAPTCHA Enterprise). Enforcement toggles per app.
+- **IAM & Settings**
+  - Role-based access (Owner, Admin, Developer, Support, Analyst). Service accounts per environment with limited scopes.
+  - Audit logs, alerting via Google Cloud Monitoring, billing exports enabled.
+
+---
+
+## 4. Security Wireframes
+
+### 4.1 Current Security Posture
+- **Admin Security Panel**
+  - Minimal settings page: enable/disable registration, set password policy (length only), view login history (basic list).
+  - No visualization of rate limits, no incident workflow.
+- **User Account Security Screen**
+  - Change password form, show recent logins, logout all sessions button.
+- **Infrastructure Diagram (textual)**
+  - Single web server (Apache), MySQL, Redis. No WAF, no CDN, no AV pipeline.
+- **Policies**
+  - Manual secrets rotation, no compliance checklist, no automated scans.
+
+### 4.2 Upgraded Security Wireframe
+- **Security Command Center (Web)**
+  - Dashboard cards: Auth Status (2FA adoption), Session Health, Rate Limit events, ClamAV queue, Incident timeline, Compliance checklist.
+  - Tabs:
+    1. **Authentication**: Manage MFA enforcement, WebAuthn registrations, session expiration policies, device trust list. Visual map of login locations (with suspicious highlight). IP allowlist editor with CIDR input and approval workflow.
+    2. **Authorization**: RBAC matrix, permission diff viewer, recent policy overrides, role provisioning workflow (request → approve → activate).
+    3. **Threat Protection**: Rate limit graph, bot detection status, firewall/WAF integration toggles, hCaptcha config, DDoS alerts.
+    4. **Data Protection**: Encryption settings, data retention schedules, right-to-erasure requests queue, export requests log, PII field catalog with encryption status.
+    5. **File Security**: Upload pipeline monitor (scan status, quarantine items list, manual review queue), media policy settings (size limits, allowed types, auto-delete schedule).
+    6. **Compliance & Audits**: Checklist (SOC2, GDPR, FERPA) with tasks, document upload, attestation tracker, audit log export scheduling.
+    7. **Incident Response**: Playbook builder, active incidents list (severity, owner, timeline), communication templates, post-mortem repository.
+  - Settings: security alert routing (Email, SMS, Slack, PagerDuty), severity thresholds, automation toggles (auto-disable compromised accounts), secrets rotation scheduler with integrations (AWS KMS, HashiCorp Vault).
+- **End-User Security Settings (Web & Mobile)**
+  - Manage passkeys, TOTP, backup codes, session/device list (revoke), login notifications, connected apps, privacy controls, data download/delete account flow.
+  - Security status indicator with checklist (Complete profile, Enable 2FA, Review devices).
+- **Infrastructure Map Wireframe**
+  - Layers showing WAF/CDN, load balancers, web app cluster, queue workers, background scanners, logging/monitoring stack (ELK, Prometheus/Grafana), security services (ClamAV, Vault), backup systems.
+  - Control plane view: CI/CD pipeline with SAST/DAST gates, artifact signing, deployment approval steps.
+
+---
+
+## 5. Traceability Matrix (Wireframes to Requirements)
+
+| Scope | Current Coverage | Upgrade Goals |
+| --- | --- | --- |
+| Web Admin | Basic LMS-focused metrics, limited settings | Full community ops, monetization, automation, compliance, geo, RBAC |
+| Web User Roles | Instructor/Student only | Expanded roles with personalized workspaces and governance |
+| Mobile Admin | Simple revenue/students view | Comprehensive operations, moderation, automation, security settings |
+| Mobile Users | Course consumption | Community feed, events, rewards, moderation tools |
+| Firebase | Minimal FCM usage | Multi-service setup with security, analytics, automation |
+| Security | Basic toggles | Centralized security ops center with automation and compliance |
+
+---
+
+## 6. Wireframe Notation Legend
+
+- **Tabs** represent segmented navigation within a screen.
+- **Cards** denote modular widgets with individual settings.
+- **FAB** indicates floating action button for quick creation.
+- **Matrix/Grid** references permission or metric tables with interactive controls.
+- **Queues** represent task/incident lists with state transitions.
+- **Settings** sections are exhaustive, including toggles, selectors, thresholds, integration keys, and audit hooks.
+

--- a/Academy/docs/wireframes/branding-visual-identity-guide.md
+++ b/Academy/docs/wireframes/branding-visual-identity-guide.md
@@ -1,0 +1,116 @@
+# Branding, Landing Pages, and Visual Identity Guide
+
+## Overview
+This guide documents the current branding assets and defines the upgraded visual identity system across landing pages, typography, color schemes, buttons, cards, and logo management. It includes admin controls for configuring defaults, uploading assets, and enforcing consistency across web and mobile applications.
+
+## 1. Brand Foundations
+
+### 1.1 Current State
+- **Logo usage**: Primary horizontal logo (blue text on white) used on web header and login screen. No dark-mode variant. Favicon uses outdated icon.
+- **Color palette**: Primary blue `#2E5BFF`, secondary green `#00C48C`, accent orange `#FFB74D`, neutrals limited to grayscale `#1F1F1F`–`#F5F5F5`. No documented palette usage or tokenization.
+- **Typography**: `Poppins` headings, `Open Sans` body. No brand typography guidelines, font files loaded via Google Fonts CDN.
+- **Imagery**: Stock photography featuring classroom scenes. No illustration system or iconography guidelines.
+- **Voice & tone**: Not documented; landing page copy mixes course-centric messaging with community hints.
+- **Admin controls**: Branding settings limited to uploading logo (single slot) and specifying primary color hex.
+
+### 1.2 Upgraded Identity System
+- **Logo system**: Horizontal, stacked, and icon-only marks. Provide light and dark variants (SVG). Include safe area guidance (1x logo height). Define minimum size (24px icon, 120px horizontal) and clear space rules.
+- **Color palette**:
+  - **Core palette**: Primary `#3056D3`, Primary Dark `#1F3A8A`, Accent `#00B894`, Secondary `#F97316`, Neutral 900 `#0F172A`, Neutral 700 `#1E293B`, Neutral 500 `#64748B`, Neutral 300 `#CBD5F5`, Neutral 100 `#F8FAFC`.
+  - **Extended palette**: Status colors—Success `#0EA5E9`, Warning `#F59E0B`, Danger `#DC2626`, Info `#3B82F6`.
+  - Provide usage ratios (60% neutral, 25% primary, 10% accent, 5% highlight). Document accessible combinations.
+- **Typography**:
+  - Display: `Clash Display` (weights 500/600) for hero headlines and callouts.
+  - Body: `Inter` (weights 400–700) for UI copy, `Inter 300` for captions.
+  - Monospace: `IBM Plex Mono` for code snippets and data labels.
+  - Provide typographic scale with `clamp` values for responsive sizing.
+  - Document usage contexts (Display for hero, Headline for section titles, Body for paragraphs, Label for buttons).
+- **Imagery & illustration**:
+  - Establish brand illustration style (geometric gradients, abstract community motifs). Provide asset library in SVG.
+  - Photography guidelines: Diverse communities, candid collaboration, consistent lighting. Provide color grading presets.
+  - Iconography: Use Phosphor Icons with 1.5px stroke for outline set, filled variant for active states.
+- **Voice & tone**:
+  - Voice pillars: Empowering, Insightful, Approachable.
+  - Tone adjustments: Excited for launches, Calm for support, Direct for compliance messaging.
+  - Provide copy examples per surface (landing hero, feature highlight, error message).
+- **Motion**:
+  - Define motion principles: purposeful, subtle, supportive. Standard durations (fast 120ms, medium 200ms, slow 320ms). Use easing `cubic-bezier(0.4, 0, 0.2, 1)`.
+  - Provide animation tokens for hero background gradients and card hover lifts.
+
+## 2. Landing Page System
+
+### 2.1 Current State
+- Single landing page with static sections, minimal personalization. Form submissions handled via Mailchimp embed. No AB testing.
+
+### 2.2 Upgraded Landing Framework
+- **Section catalog**: Hero, Product Overview, Features, Community Showcase, Testimonials, Pricing, FAQ, CTA Banner, Footer.
+- **Hero layout**: Split screen (copy vs. imagery), gradient background (primary 500 → accent 500). CTA button pair (primary solid, secondary outline). Social proof row with logos.
+- **Feature section**: 3x2 grid with cards including icon, title, description, micro-CTA. Use CSS Grid with `repeat(auto-fit, minmax(240px, 1fr))`.
+- **Community showcase**: Carousel showing community cards with stats. Provide filters (Industry, Region, Membership level).
+- **Pricing section**: Toggle monthly/annual, display cards with plan details, CTA. Provide feature comparison table.
+- **FAQ accordion**: Expand/collapse with smooth animation, arrow rotation.
+- **Footer**: Multi-column with quick links, resources, policies. Include language selector, theme toggle.
+- **Personalization**: Use geolocation and referral parameters to adjust hero copy and testimonial order.
+- **Experimentation**: Integrate with LaunchDarkly for variant testing. Provide content management via CMS (Prismic or Sanity) with preview environment.
+
+## 3. Component Styling (Buttons, Cards, Forms)
+
+### 3.1 Buttons
+- **Variants**: Primary solid, Primary outline, Secondary solid, Tertiary ghost, Icon-only.
+- **States**: Default, hover, focus, active, disabled, loading. Document color, shadow, border, text changes per state.
+- **Sizing**: Small (36px height), Medium (44px), Large (52px). Padding `0 var(--space-500)` for medium. Icon placement guidelines (8px gap).
+- **Mobile**: Expand full width for primary CTAs. Provide min tap target 48px.
+- **Admin controls**: Toggle gradient usage, set default radius, update copy style (sentence vs. title case).
+
+### 3.2 Cards & Surfaces
+- **Card types**: Feature card, Metric card, Feed card, Testimonial card, Pricing card.
+- **Styling**:
+  - Radius tokens (8px, 16px, 24px).
+  - Shadow tokens tied to elevation.
+  - Border accent using 3px top border for highlight.
+  - Provide background overlays for hero cards (gradient overlay 0.8 opacity).
+- **Content structure**: Header, meta, body, actions. Use spacing tokens for vertical rhythm.
+- **Admin controls**: Manage card templates, reorder sections, update icon selection.
+
+### 3.3 Forms
+- **Layout**: Use two-column grid on desktop, single column on mobile. Align labels top-left, helper text below input.
+- **Controls**: Text input, textarea, select, multi-select, toggle, radio, checkbox, slider, file upload.
+- **Validation**: Provide inline error message, icon, border color shift to `--color-danger-500`. Provide success state with checkmark.
+- **Accessibility**: Associate labels via `for`/`id`, provide `aria-describedby` for helper text.
+- **Admin controls**: Create form templates, manage custom fields, set conditional logic, preview states.
+
+## 4. Logo and Asset Management in Admin Panel
+- **Current**: Single upload field for logo.
+- **Upgraded**:
+  - Asset manager with folders (Logos, Icons, Backgrounds). Support drag-and-drop, version history, alt text metadata.
+  - Logo upload wizard: Upload light/dark variants, favicon, app icon (512px). Provide cropping and background removal tool.
+  - Automatic asset optimization (WebP, AVIF) with fallback. Provide CDN URLs.
+  - Theme preview: Show logos on dark/light backgrounds, header, footer, mobile splash.
+  - Permissions: Restrict branding changes to `Brand Manager` role; require approval workflow.
+
+## 5. Typography Controls
+- **Font sourcing**: Integrate with Adobe Fonts/Google Fonts API. Allow custom font upload (WOFF2) with license acknowledgement.
+- **Fallback stacks**: `"Inter", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", sans-serif`.
+- **Scaling**: Provide slider to adjust base font size (14–18px) with preview. Save per community.
+- **Line height & letter spacing**: Provide defaults per heading level; allow adjustments with guardrails to maintain readability.
+- **Mobile typography**: Provide responsive `clamp` values to ensure readability on small screens.
+
+## 6. Branding Governance
+- **Brand board**: Central dashboard summarizing current assets, last update, responsible owner.
+- **Approval workflow**: Submit brand change → Reviewer approves/requests edits → Publish with change log.
+- **Audit log**: Track asset uploads, color changes, typography updates with timestamp, user, before/after preview.
+- **Versioning**: Snapshot brand configuration per release. Allow rollback to previous version.
+- **Guidelines distribution**: Auto-generate PDF/Notion export of brand guidelines for partners.
+
+## 7. Mobile Branding Implementation
+- **Splash screen**: Dynamic background gradient based on primary color. Logo scaling to 60% of width, fallback to icon for narrow devices.
+- **App icon**: Provide layered vector assets for iOS/Android. Manage icon updates in admin panel with release preview.
+- **In-app theming**: Bind colors and typography to theme extension tokens. Provide toggles for dark mode accent levels.
+- **Branding sync**: On brand update, push config via remote config. Provide manual refresh option in app settings.
+
+## 8. Landing Page Content Controls
+- **Content blocks**: Manage hero copy, feature list, testimonials, case studies via CMS. Provide inline editing with preview.
+- **Dynamic inserts**: Support personalization tokens ({{first_name}}, {{industry}}). Provide fallback content.
+- **Localization**: Manage translations with language-specific assets. Provide translation memory.
+- **SEO controls**: Edit meta title, description, OG tags per landing variant. Provide structured data snippets.
+

--- a/Academy/docs/wireframes/css-ui-styling-design.md
+++ b/Academy/docs/wireframes/css-ui-styling-design.md
@@ -1,0 +1,93 @@
+# CSS & User Interface Styling and Design Guide
+
+## Overview
+This guide documents the current styling conventions and the target upgraded design system for the Academy web application and Flutter mobile app. It covers layout scaffolding, component styling, states, responsive behavior, and accessibility treatments to ensure a cohesive experience across surfaces.
+
+## 1. Web Application Styling
+
+### 1.1 Current Styling Baseline
+- **Framework mix**: Bootstrap 5 grid with legacy custom CSS under `public/assets/frontend/css`. Inline styles common in Blade templates for hero sections and course cards.
+- **Color usage**: Primary `#2E5BFF`, secondary `#00C48C`, backgrounds `#F5F7FB`, but inconsistent contrast on banners (`#F1F6FF` text overlay `#FFFFFF`). Alerts reuse Bootstrap contextual classes without theme overrides.
+- **Typography**: Google Fonts `Poppins` for headings (`700/600 weights`), `Open Sans` body (`400`). Font sizes hard-coded per template; limited use of CSS variables. Line heights vary (1.2–1.8) causing rhythm mismatch.
+- **Spacing**: Reliance on Bootstrap utility classes (`pt-5`, `mb-4`). Section padding inconsistent due to nested containers. No vertical rhythm scale.
+- **Buttons**: Bootstrap `.btn-primary` / `.btn-outline-primary` with custom gradient overrides on hero. Hover states lighten background but do not change border color. Focus outlines removed via `outline: none`.
+- **Forms**: Default `.form-control` with square edges. Validation feedback uses Bootstrap `.invalid-feedback` but not triggered for AJAX submissions.
+- **Cards**: Course cards use shadow `0 15px 25px rgba(46,91,255,0.15)`; admin widgets use flatter `0 3px 6px rgba(0,0,0,0.08)`. Border radius inconsistent (`6px`, `12px`, `20px`).
+- **Navigation**: Sticky header with dark mode toggle absent; mobile nav collapses to hamburger but lacks animation. Active states rely on `.active` class color swap.
+- **Tables**: Admin uses Bootstrap striped tables with minimal spacing. No row hover highlight. Actions appear as inline icons without tooltips.
+- **Modals**: Default Bootstrap modals with static backdrop for destructive actions but without accent color alignment.
+- **Responsive behavior**: Breakpoints follow Bootstrap defaults (`576/768/992/1200`), but hero images break on `lg` due to fixed heights.
+- **Accessibility**: Skip links missing. Focus states suppressed. Text contrast occasionally below AA (CTA on hero: `#FFFFFF` on `#2E5BFF` meets AA for large text but not small body copy).
+
+### 1.2 Upgraded Styling Vision
+- **Design tokens**: Introduce CSS variables in `:root` for colors, typography, spacing, elevation, radii.
+  - Colors: `--color-primary-500 #3056D3`, `--color-primary-600 #2544B0`, `--color-accent-500 #00B894`, `--color-surface-100 #F6F8FC`, `--color-surface-900 #0F172A`.
+  - Typography scale: `--font-size-900 3.5rem`, `--font-size-800 2.75rem`, `--font-size-700 2rem`, `--font-size-600 1.5rem`, `--font-size-500 1.25rem`, `--font-size-400 1rem`, `--font-size-300 0.875rem`.
+  - Spacing scale: `--space-100 4px`, `--space-200 8px`, `--space-300 12px`, `--space-400 16px`, `--space-500 20px`, `--space-600 24px`, `--space-700 32px`, `--space-800 40px`, `--space-900 56px`.
+  - Elevation tokens: `--elevation-100 0 1px 2px rgba(15,23,42,0.08)`, `--elevation-200 0 6px 12px rgba(15,23,42,0.12)`, `--elevation-300 0 12px 24px rgba(15,23,42,0.16)`.
+- **Global resets**: Adopt `@layer base` with modern CSS reset (Open Props or Tailwind preflight equivalent). Use container queries for layout adjustments beyond breakpoints.
+- **Typography**: Switch to `Inter` for UI text (weights 400–700) and `Clash Display` for hero headlines (weights 500/600). Apply fluid typography (`clamp`) for responsive scaling.
+- **Layout grid**: Introduce `max-width` containers (`1200px` standard, `1440px` admin analytics). Use CSS Grid for dashboards (auto-fit columns) and `flex` for navigation. Define content gutter tokens (`var(--space-700)` desktop, `var(--space-400)` mobile).
+- **Buttons**: Build `.btn` variants with CSS custom properties for color transitions, focus rings, icon alignment. Provide `solid`, `outline`, `ghost`, `link`. Use `transition: background-color 160ms ease, box-shadow 160ms` and focus ring `0 0 0 3px rgba(48,86,211,0.35)`.
+- **Forms**: Introduce component classes for text fields, selects, toggles. Provide inline validation icons, helper text, success state. Support `:disabled`, `:read-only`, `:focus-visible`. Group labels with `font-weight 600`.
+- **Cards**: Standardize radius `var(--radius-lg 16px)` and `var(--radius-sm 8px)`. Use gradient top border for featured modules. Provide card header, body, footer structure with spacing tokens.
+- **Navigation**: Build responsive `mega-nav` for admin with segmented controls, filter chips. Provide micro-interactions (underline animation) using `transform`.
+- **Tables**: Convert to CSS Grid tables with sticky headers, zebra stripes `rgba(48,86,211,0.04)`. Provide row selection states, inline badges.
+- **Modals, drawers**: Add slide-in drawers for filters. Apply `backdrop-filter: blur(6px)` and `box-shadow var(--elevation-300)`.
+- **Dark mode**: Provide `data-theme="dark"` palette overrides using CSS variables. Ensure 4.5:1 contrast minimum.
+- **Accessibility**: Re-enable focus outlines via `:focus-visible`. Add skip link anchored to `#main`. Provide `prefers-reduced-motion` adjustments.
+
+## 2. Mobile App Styling (Flutter)
+
+### 2.1 Current Styling Baseline
+- **ThemeData**: Primary color `Color(0xFF2E5BFF)`, secondary `Color(0xFF00C48C)`, accent `Color(0xFFFFB74D)`. Typography uses `GoogleFonts.poppinsTextTheme()` overriding Material defaults.
+- **Components**: ElevatedButtons with `RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))`. FloatingActionButton standard circular. AppBar uses solid primary background, white text.
+- **Spacing**: Magic numbers (`EdgeInsets.symmetric(horizontal: 24, vertical: 18)`) repeated. No centralized spacing scale.
+- **Cards**: `Card(elevation: 4, shape: RoundedRectangleBorder(BorderRadius.circular(16)))`. Shadow color default black 0.2.
+- **List tiles**: Use `ListTile` with icons tinted primary. Dividers default `Divider()`.
+- **Forms**: `InputDecoration` with filled grey backgrounds, label style `FontWeight.w600`. Error color default Material red.
+- **State styles**: Loading indicators default `CircularProgressIndicator`. No skeleton loaders.
+- **Dark mode**: Not implemented; app locked to light theme.
+
+### 2.2 Upgraded Styling Vision
+- **Design system**: Introduce `ThemeExtension` for tokens.
+  - Colors: `primary = Color(0xFF3056D3)`, `primaryDark = Color(0xFF1F3A8A)`, `secondary = Color(0xFF00B894)`, `warning = Color(0xFFF59E0B)`, `error = Color(0xFFDC2626)`, `background = Color(0xFFF8FAFC)`, `surface = Color(0xFFFFFFFF)`.
+  - Radii: `Radius.small = 8`, `Radius.medium = 12`, `Radius.large = 20`.
+  - Elevation: `ShadowLevel.low = BoxShadow(color: Color(0x1A0F172A), blurRadius: 8, offset: Offset(0,4))`, `medium` and `high` increments.
+  - Spacing: `AppSpacing.xs = 4`, `sm = 8`, `md = 12`, `lg = 16`, `xl = 24`, `xxl = 32`.
+- **Typography**: Use `TextTheme` with `DisplayLarge` for hero, `HeadlineMedium` for dashboards, `BodyLarge` for standard copy. Implement `GoogleFonts.inter()` base and `ClashDisplay` for hero headlines.
+- **Component theming**:
+  - `FilledButtonThemeData` with gradient backgrounds (primary to accent). Provide `ButtonStyle` with `MaterialStateProperty` for hover, focus, disabled.
+  - `OutlinedButtonThemeData` uses 1.5px border, stateful color transitions.
+  - `CardTheme` uses `shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20))`, `clipBehavior: Clip.antiAlias`, custom `shadowColor` from tokens.
+  - `BottomNavigationBarTheme` with pill indicator `AnimatedContainer`, active icon tinted `primary`, label style `fontWeight.w600`.
+  - `TabBarTheme` includes dynamic indicator width based on label size.
+- **Dark mode**: Provide `ThemeMode.system` with `ColorScheme.dark` mapping (primary `0xFF93C5FD`, background `0xFF0F172A`). Use `FlexColorScheme` for variant generation.
+- **Animations**: Standardize curves `Curves.easeOutCubic` and durations (fast 150ms, medium 240ms, slow 360ms). Provide shimmer skeletons using `shimmer` package.
+- **Accessibility**: Ensure `MediaQuery.textScaleFactor` up to 200% supported. Provide `highContrast` color scheme variant.
+- **Responsive layout**: Use `LayoutBuilder` breakpoints (`<600` compact, `600–1024` medium, `>1024` extended for tablets/desktop). Provide two-pane layout for tablets.
+
+## 3. Component Library Inventory
+- **Atoms**: Buttons, icon buttons, tags, badges, avatars, toggles, chips, progress indicators (linear/circular), tooltips.
+- **Molecules**: Search bars with filter chips, user summary tiles, content cards (feed, course, event), stepper, breadcrumbs.
+- **Organisms**: Dashboard hero (stats + CTA), analytics board (charts, filters), message composer, moderation queue list, forms (multi-step), onboarding wizard.
+- **Templates**: Admin dashboard layout (sidebar + header + content grid), community feed layout, course detail layout, mobile bottom nav shell.
+
+## 4. Interaction States & Micro-interactions
+- **Hover**: Buttons lighten 8%, apply shadow level increase. Cards elevate from `--elevation-100` to `--elevation-200`.
+- **Focus**: Distinct `outline` using `focus-visible` + accessible color. Provide `:focus-within` for form groups.
+- **Active**: Buttons darken 12%, translate Y by 1px. Nav links show underline slide-in animation.
+- **Disabled**: Lower opacity to 40% but retain contrast for text. Cursor `not-allowed`.
+- **Feedback**: Provide toast component with status colors, icons, and ARIA live regions.
+
+## 5. Asset Management & Delivery
+- **CSS architecture**: Adopt layered CSS (`@layer base, components, utilities`). Use SCSS modules for composition with PostCSS autoprefixer. Purge unused styles with `@fullhuman/postcss-purgecss` configured via safelist.
+- **Naming convention**: BEM-style classes for legacy compatibility; new components use CSS modules naming `component__element--modifier`.
+- **Build pipeline**: Vite with PostCSS (Autoprefixer, cssnano). Generate critical CSS for landing pages, lazy load rest.
+- **Iconography**: Use `Phosphor Icons` web + Flutter packages for consistency. Provide sprite sheet for web.
+
+## 6. Governance
+- **Design review**: Weekly design critiques with annotated Figma frames. Document accepted patterns in Storybook (web) and Widgetbook (Flutter).
+- **Versioning**: Semantic version tokens (v1.0). Document changes in `docs/design/changelog.md`.
+- **Accessibility audits**: Quarterly AXE scans + manual screen reader testing. Track issues in Jira board.
+

--- a/Academy/docs/wireframes/css-ux-organization-flow.md
+++ b/Academy/docs/wireframes/css-ux-organization-flow.md
@@ -1,0 +1,105 @@
+# CSS & User Experience Organization and Flow Guide
+
+## Overview
+This document maps the user experience structure, layout flows, and CSS organization for both the current platform and the upgraded design system. It focuses on navigation hierarchies, layout grids, interaction logic, and responsive orchestration for the web app and mobile apps.
+
+## 1. Web Application Experience Architecture
+
+### 1.1 Current State
+- **Navigation hierarchy**:
+  - Top navigation: Home, Courses, Communities (links to placeholder), Pricing, Blog, Login/Register.
+  - Secondary admin sidebar: Dashboard, Courses, Students, Instructors, Payments, Settings. Communities absent.
+  - Footer replicates key links plus support email.
+- **Information architecture**:
+  - Landing page sections: Hero → Course categories → Featured instructors → Testimonials → Newsletter signup. Each section manually stacked using `.container` blocks.
+  - Admin dashboard layout: Sidebar (fixed 280px) + content area using Bootstrap grid. Widgets arranged via `.row .col-md-6`.
+- **Interaction flow**:
+  - Enrollment: Landing page CTA → Login/Register modal → Catalog listing → Course detail → Checkout.
+  - Admin content edit: Dashboard → Courses → Edit (tabbed: Overview, Curriculum, SEO, Pricing). Save reloads page.
+- **CSS organization**:
+  - `app.css` global, `custom.css` overrides, page-specific files under `assets/frontend/css/pages`. No component-level segmentation. Duplicated selectors (`.hero-banner h1` defined in multiple files).
+  - Media queries appended per file; no mobile-first approach. Breakpoints tied to Bootstrap defaults.
+- **Responsive behavior**:
+  - On `md` screens, hero text centers, CTA stacks, but forms overflow due to fixed widths. Sidebar collapses to off-canvas requiring manual toggle.
+- **User feedback**:
+  - Success/error messages appear as inline alerts at top of form. No toasts. Loading states use spinner overlay with `position: fixed` but not accessible.
+
+### 1.2 Upgraded Flow Vision
+- **Navigation model**:
+  - Primary nav with mega-menu for Communities (submenus: Overview, Memberships, Events, Resources).
+  - Contextual header actions per role (Create Post, Manage Automation). Introduce profile menu with quick settings, theme switcher, locale toggle.
+  - Admin global nav: Collapsible left rail (72px icon rail collapsed, 280px expanded) with section grouping (Operate, Grow, Govern). Secondary top bar for breadcrumbs and filters.
+- **Information architecture**:
+  - Landing page reorganized into narrative flow: Hero → Value Pillars → Product Surfaces (Web, Mobile, Admin) → Success Metrics → Testimonials → Pricing → FAQ → Footer CTA.
+  - Admin dashboard: Modular workspace with draggable widgets, persistent filter drawer, timeline feed for alerts.
+  - Community area: Feed → Modules (Lessons, Events) accessible via top tabs; filter chips for segmenting content.
+- **Interaction flow**:
+  - Enrollment: Multi-step flow with progress indicator (Select Plan → Account → Payment → Onboarding). Autosave form data, show stepper at top.
+  - Admin edit: Inline editing within cards (click to edit) with autosave. Bulk actions accessible via selection bar.
+  - Moderation: Alerts panel → Filter by severity → Inline decision with comment requirement → Audit log modal.
+- **CSS organization**:
+  - Adopt component-based architecture: `/resources/css/tokens`, `/resources/css/layouts`, `/resources/css/components`. Use ITCSS layering.
+  - Use SCSS partials with `@use` for tokens. Each layout has corresponding Figma frame ID references in comments.
+  - Introduce utility classes generated via PostCSS (e.g., `.u-flex-center`, `.u-gap-400`).
+- **Responsive orchestration**:
+  - Mobile-first media queries: `@media (min-width: 640px)`, `768px`, `1024px`, `1280px`.
+  - Container queries to adjust card density: feed cards show metadata stack on mobile, inline on desktop.
+  - Sidebar transitions: Off-canvas overlay on <1024px, persistent rail on ≥1024px. Use CSS transitions for width changes.
+- **User feedback**:
+  - Toast system anchored bottom-right with queue and auto-dismiss. Provide ARIA live region.
+  - Skeleton loaders for dashboards, shimmer lines for text.
+  - Form validation: inline with icon, color-coded border, accessible error summary at top.
+
+## 2. Mobile Application Experience Architecture
+
+### 2.1 Current State
+- **Navigation hierarchy**:
+  - Bottom navigation: Home, Courses, Categories, My Learning, Profile.
+  - No dedicated Communities tab. Settings accessible via profile overflow.
+  - Drawer menu on tablets replicates nav items.
+- **Screen flows**:
+  - Login → OTP (if enabled) → Home feed listing courses.
+  - Course detail: tabs for Overview, Curriculum, Reviews.
+  - Admin mobile: Hidden behind `/admin` route, uses webview rather than native screens.
+- **State handling**:
+  - Each screen fetches data on `initState`. No caching between tabs.
+  - Error states show SnackBar with generic text.
+- **Layout**:
+  - Column-based, minimal use of `Sliver` widgets. Scroll performance impacted by nested ListViews.
+  - Use of `Expanded` inconsistent; overflow on small devices.
+
+### 2.2 Upgraded Flow Vision
+- **Navigation model**:
+  - Five-tab bottom nav: Feed, Learn, Events, Messages, Profile. Contextual FAB (Compose) appears on Feed and Messages.
+  - Admin persona switcher accessible via Profile → Admin Console (native screens) with segmented controls.
+  - Global search accessible via top app bar with hero search field, filter drawer slide-over.
+- **Screen flows**:
+  - Onboarding wizard: Welcome → Personalize interests → Choose communities → Notifications opt-in. Each step uses progress indicator and skip logic.
+  - Feed: Cards for posts, pinned announcements, events. Pull-to-refresh, infinite scroll with keyset pagination.
+  - Events: Calendar view (monthly) + list; support RSVP and add-to-calendar actions.
+  - Admin dashboard mobile: KPIs carousel, moderation queue list with swipe actions, approvals sheet.
+  - Offline flows: Provide offline banner, cached content view, retry button.
+- **State handling**:
+  - Adopt Riverpod for state management with `AsyncNotifier`. Use `StatefulShellRoute` for tab persistence.
+  - Preload data via background isolates. Implement caching using `Hive` or `Drift`.
+- **Layout**:
+  - Use `CustomScrollView` + `SliverAppBar` for feed, `SliverGrid` for community discovery.
+  - Define responsive breakpoints for tablets with two-pane layout (list + detail).
+- **Feedback**:
+  - Toast/snackbar patterns unified with design tokens. Inline validation on forms.
+  - Provide success checkmark animations for completed actions.
+
+## 3. Flow Diagrams & Logic Mapping
+- **Navigation graph (web)**: Documented in Figma with nodes for Landing, Community Feed, Events, Admin Dashboard, Settings. Each edge annotated with access control (role: guest, member, admin).
+- **State diagrams**:
+  - Form submission: Idle → Editing → Validating → Error/Success. Add loading overlay with accessible status text.
+  - Moderation queue: Pending → Under Review → Resolved (Approve/Reject) → Archived.
+- **Journey mapping**:
+  - Guest to Member: Landing → Pricing → Checkout → Onboarding → Community Selection → Feed Tour. Include tooltips guiding new features.
+  - Moderator workflow: Alert → Queue → Review detail (media viewer, history) → Action → Audit log.
+
+## 4. Governance & Documentation
+- **CSS documentation**: Generate Storybook with controls and docs tab referencing tokens. Include guidelines for layout usage per breakpoint.
+- **UX playbooks**: Maintain FigJam journey maps for new features. Capture heuristics review (Nielsen) for each release.
+- **Accessibility**: Provide keyboard nav map, screen reader labels inventory, color contrast audit log.
+

--- a/Academy/docs/wireframes/dummy-content-management-guide.md
+++ b/Academy/docs/wireframes/dummy-content-management-guide.md
@@ -1,0 +1,77 @@
+# Dummy Content, Placeholder Management, and Data Reset Guide
+
+## Overview
+This guide covers how dummy text, seed content, placeholders, and wipes are handled across the current platform and the upgraded system. It details admin controls for inserting, editing, and purging sample data across web and mobile experiences to support demos, QA, and onboarding.
+
+## 1. Current Dummy Content Practices
+- **Seed data**: Laravel seeders populate demo courses, instructors, and testimonials. No community-specific content. Text stored in English only.
+- **Placeholders**: Landing page uses lorem ipsum blocks within Blade templates. Mobile app includes fallback copy within Dart widgets.
+- **Media assets**: Default hero images stored in `public/uploads/demo`. No CDN integration. File naming inconsistent.
+- **Reset controls**: Admin panel lacks dedicated reset options. Developers run artisan commands manually (`php artisan db:seed`).
+- **User accounts**: Demo accounts manually created; passwords shared via email. No automated rotation.
+
+## 2. Upgraded Dummy Content Strategy
+
+### 2.1 Content Taxonomy
+- **Content categories**: Communities, Posts, Events, Courses, Modules, Automations, Members, Announcements.
+- **Locale support**: Provide base dummy content in English (en), Spanish (es), French (fr). Each locale has translations for major flows.
+- **Persona-based copy**: Define personas (Creator, Community Manager, Instructor, Learner). Provide tailored copy segments for each persona’s experience.
+
+### 2.2 Content Library
+- **Central repository**: Store dummy content JSON in `/storage/app/dummy-content`. Structure by module (e.g., `feed/posts.json`, `events/calendar.json`).
+- **Versioning**: Each file includes metadata (version, created_at, updated_by). Use Git for history; expose in admin UI.
+- **Asset management**: Store images/videos in S3 `dummy-assets` bucket with lifecycle policy. Provide responsive variants.
+- **Rich media**: Include sample polls, quizzes, attachments. Provide alt text and captions.
+
+### 2.3 Generation & Rotation
+- **Seeder scripts**: Artisan commands `academy:dummy:load`, `academy:dummy:reset`, `academy:dummy:rotate`.
+  - `load`: Inserts baseline content for selected modules.
+  - `reset`: Clears module data (respecting dependencies), reseeds defaults.
+  - `rotate`: Swaps content sets (Seasonal, Industry-specific) without wiping user data.
+- **Scheduling**: Cron job to rotate spotlight posts weekly for demo environments.
+- **Randomization**: Provide template variables ({{first_name}}, {{community_name}}) resolved at load time using faker.
+
+## 3. Admin Panel Controls
+- **Dummy content dashboard**:
+  - Overview cards showing modules seeded, last update, next rotation.
+  - Toggle per module (Communities, Posts, Events, Automation). Each toggle shows record counts.
+  - Preview pane with rendered sample data (web + mobile views).
+- **Import/export**:
+  - Upload JSON/CSV to update dummy content. Validate schema before commit.
+  - Export current dummy dataset for external editing. Provide diff viewer.
+- **Editing**:
+  - Inline editor with markdown support, translation tabs, persona variants.
+  - Bulk edit using spreadsheet-like grid (Handsontable integration).
+  - Media picker for attaching images/videos. Provide cropping and caption fields.
+- **Reset & wipe actions**:
+  - Soft wipe: Archive dummy data (mark hidden) without deletion.
+  - Hard wipe: Delete dummy records and associated media. Confirmation modal with double-entry of environment name.
+  - Scheduled wipe: Configure automatic reset on environment teardown.
+- **Permissions**:
+  - Roles: `Content Demo Manager`, `QA Lead`, `Product Marketing`. Each has scoped permissions (view, edit, reset, approve).
+  - Approval workflow: Edits require second reviewer before publish to demo environments.
+
+## 4. Mobile App Integration
+- **Remote config**: Fetch dummy content toggles via Firebase Remote Config. Allows enabling demo mode without app update.
+- **Demo mode switch**: Profile → Settings → Enable Demo Content (requires admin role). Switch triggers data fetch and caches locally.
+- **Offline handling**: Dummy content packaged in app bundle for offline demo. Provide asset manifest.
+- **Reset flows**: Option to clear dummy data via Settings → Storage → Reset Demo Data. Prompts confirmation and restarts app state.
+
+## 5. Data Isolation & Safety
+- **Environment segmentation**: Dummy content available only in staging, demo, sandbox environments. Production requires explicit enablement and is audited.
+- **Identifier namespaces**: Use prefixed IDs (`demo_community_001`) to prevent collisions. Ensure analytics filters exclude demo data.
+- **Privacy**: No PII in dummy content. Media uses generated personas.
+- **Audit logging**: Record actions (load, reset, edit) with user, timestamp, environment. Expose in admin audit log.
+
+## 6. Automation & Tooling
+- **CLI tools**: Provide `academy:dummy:status` to display counts, next rotation, errors.
+- **API endpoints**: `/api/admin/dummy/preview`, `/api/admin/dummy/reset`, `/api/admin/dummy/export`. Secure via token + role.
+- **CI integration**: On deploy to demo environment, run `academy:dummy:load --module=communities,feed` as part of pipeline.
+- **Testing**: Automated tests ensure dummy content loads without validation errors. Provide contract tests for JSON schema.
+
+## 7. Documentation & Governance
+- **Playbook**: Document procedures for enabling/disabling dummy content, rotating sets, troubleshooting failures.
+- **Change log**: Maintain `docs/dummy-content/changelog.md` tracking updates, owners, rationale.
+- **Access control**: Quarterly review of demo content permissions.
+- **Training**: Provide video walkthrough for sales and marketing teams on using dummy content scenarios.
+

--- a/Academy/docs/wireframes/page-screen-admin-designs.md
+++ b/Academy/docs/wireframes/page-screen-admin-designs.md
@@ -1,0 +1,154 @@
+# Page Designs, Screens, and Admin Control Guide
+
+## Overview
+This guide provides a comprehensive inventory of page and screen designs across the web and mobile experiences, detailing the current implementations and the upgraded blueprint. It includes admin panel controls, data entry workflows, and full edit/insert logic for every surface.
+
+## 1. Web Application Pages
+
+### 1.1 Landing & Marketing Pages
+- **Current**
+  - Hero section: Static background image, CTA button linking to `/register`. Form overlay uses Bootstrap modal. No personalization.
+  - Feature sections: Three-column cards describing course modules; minimal iconography.
+  - Testimonials: Carousel with manual jQuery plugin; lacks accessibility controls.
+  - Footer: Four-column list of links; newsletter form posts to Mailchimp embed.
+- **Upgraded**
+  - Dynamic hero: Background video (muted, looped) with fallback image; CTA segmented (Explore Communities, Start Trial). Personalization banner uses user geolocation + industry persona.
+  - Feature sections: Four cards with iconography (Phosphor). Include hover micro-interactions and deep-link CTAs to relevant community verticals.
+  - Social proof: Testimonial grid with video modals, star ratings, and dynamic review feed. Provide filters by persona.
+  - Footer: Mega footer with product, company, resources, legal columns. Include social icons, locale switcher, trust badges.
+  - Landing page settings: Admin can reorder sections, toggle modules, update copy via CMS (structured blocks) with preview mode.
+
+### 1.2 Authentication & Onboarding
+- **Current**
+  - Login/Register modals with email/password fields, optional social logins disabled.
+  - Password reset page with email input.
+  - Onboarding limited to welcome email.
+- **Upgraded**
+  - Dedicated login page with left brand panel, right form card. Supports email, SSO (Google, Microsoft), and passwordless link.
+  - Registration: Multi-step (Account → Profile → Preferences). Optional invite code input validated server-side.
+  - Onboarding wizard: Video tour, community preference selection, notification opt-in, default communication channel selection.
+  - Admin controls: Toggle required fields, define custom profile questions, manage invite quotas.
+
+### 1.3 Community & Feed
+- **Current**
+  - Communities page: Static grid of community cards linking to placeholder.
+  - Feed absent.
+- **Upgraded**
+  - Community discovery: Filterable grid with categories, membership badges, member count, growth trend sparkline.
+  - Community detail: Tabs (Feed, Modules, Events, Members, Resources). Header banner with join/leave button, status indicator.
+  - Feed: Infinite scroll list, composer at top with attachments (image, video, file, poll), scheduling panel. Reactions, comments, share actions, moderation flags.
+  - Admin feed settings: Configure default sort, moderation rules, auto-moderation thresholds, pinned posts, feed segmentation.
+
+### 1.4 Learning Modules & Resources
+- **Current**
+  - Course detail page with curriculum accordion, instructor bio, reviews.
+  - Resource library accessible via `/resources` listing.
+- **Upgraded**
+  - Module overview: Combined course + community resources with progress tracker, recommended next actions.
+  - Resource cards: Tagging, format labels, quick add to playlists.
+  - Lesson player: Theater mode with chat sidebar, transcripts, download controls (if permitted). Support polls, Q&A, timestamps.
+  - Admin: Create/organize modules, define prerequisites, manage access tiers.
+
+### 1.5 Events & Calendar
+- **Current**
+  - Basic calendar page listing upcoming webinars; RSVP by linking to Zoom.
+- **Upgraded**
+  - Events hub: Calendar (month/week/list) with filters by community, type, location. Cards show RSVP status, capacity, waitlist.
+  - Event detail: Agenda timeline, speaker bios, materials, add-to-calendar integration, host controls.
+  - Admin: Create recurring events, manage check-in, post-event surveys, analytics (attendance, engagement).
+
+### 1.6 Admin Dashboard & Settings
+- **Current**
+  - Dashboard: KPI cards (students, instructors, revenue) plus course table.
+  - Settings: Tabs for General, Payment, Email; limited toggles.
+- **Upgraded**
+  - Dashboard: Customizable layout with widgets (Cohort Retention, Revenue, Moderation, Automation). Real-time data with auto-refresh.
+  - Moderation center: Queue with filter chips, evidence viewer, action drawer, audit log.
+  - Automation suite: Builder canvas with triggers, conditions, actions. Library of templates.
+  - Settings: Multi-section (Organization, Branding, Authentication, Integrations, Billing, Legal). Each section has granular toggles, environment-specific configs.
+  - Role management: Matrix view with permissions per role. Bulk assign via CSV import.
+  - Admin controls: In-place editing with autosave, version history, preview mode.
+
+## 2. Mobile App Screens
+
+### 2.1 Member Experience
+- **Current**
+  - Home tab: Course cards list.
+  - Course detail: Video player with tabs.
+  - Profile: Basic details, toggle for notifications.
+- **Upgraded**
+  - Feed tab: Post cards, pinned highlight, quick actions row (Create Post, Event RSVP, Poll). Composer supports text, media, voice note, scheduled posts.
+  - Learn tab: Modular track view, progress ring, recommended modules, offline downloads manager.
+  - Events tab: Calendar with day agenda slider. Event detail provides RSVP, location map, join livestream.
+  - Messages tab: Direct messages and group chats. Support reactions, attachments, read receipts.
+  - Profile tab: Achievements, stats, membership badges, preferences, device management. Settings sheet for notifications, privacy, language.
+  - Offline states: Cached posts, offline banner, retry controls. Provide skeleton placeholders.
+
+### 2.2 Admin & Moderator Screens
+- **Current**
+  - No native admin interface; rely on webview.
+- **Upgraded**
+  - Admin dashboard: KPI carousel, moderation queue list, quick approve/reject actions with reason codes.
+  - Automation alerts: List of triggered workflows with action status.
+  - Member management: Search, filter, view profile, adjust roles, send DM, reset password.
+  - Event management: Edit details, manage attendees, send announcements.
+  - Settings: Manage branding assets (logo, accent color), toggle features per community, manage payment settings (Stripe connect), configure notification defaults.
+  - Incident response: Alert center with severity badges, quick escalate action (call, email, Slack).
+
+## 3. Insert, Edit, and Control Logic
+
+### 3.1 Content Creation (Web & Mobile)
+- **Composer**
+  - Rich text editor with formatting toolbar (bold, italic, code, bulleted, numbered lists, mentions, inline media).
+  - Attachment panel: Upload images (drag & drop), video, documents, polls, events, tasks. Media pipeline triggers virus scan, transcoding, thumbnail generation.
+  - Scheduling: Choose publish time, recurrence, timezone. Queue display for pending posts.
+  - Drafts: Auto-save every 10 seconds; drafts accessible from composer dropdown.
+- **Moderation**
+  - Pre-publish checks: Keyword filtering, link scanning. Provide warnings with override option for admins.
+  - Post-publish: Report flow with categories, attachments (screenshots). Moderators see context, history.
+
+### 3.2 Admin CRUD Interfaces
+- **Community management**
+  - Create community: Form sections (Basics, Branding, Access, Monetization, Automation). Live preview.
+  - Edit community: Tabbed layout with autosave. Track unsaved changes, confirm navigation.
+  - Delete/Archive: Requires reason, confirmation, optional export.
+- **Member management**
+  - Invite: Upload CSV, preview parsed entries, assign role, send invites.
+  - Edit member: Adjust roles, add notes, assign tags, set onboarding status.
+  - Bulk actions: Select multiple members, apply tag, send message, export data.
+- **Event management**
+  - Create event: Steps (Details, Schedule, Hosts, Access, Notifications). Support multi-session events.
+  - Check-in: QR scan, manual mark, export attendance.
+  - Post-event: Trigger follow-up automation, collect feedback.
+- **Billing & Pricing**
+  - Create tier: Set price, billing cycle, trial length, benefits, limited seats.
+  - Promo codes: Define code, discount type, usage limits, expiration, segment eligibility.
+  - Reports: Revenue analytics, churn, failed payments. Provide filters, export.
+
+### 3.3 Settings Controls
+- **Branding**
+  - Upload logos, icons, hero images. Validate file type/size. Provide cropping tool.
+  - Color pickers with contrast checkers. Provide presets.
+  - Typography: Choose from approved font list or upload custom (with license acknowledgment).
+- **Security**
+  - Enable 2FA (TOTP, SMS, WebAuthn). Manage trusted devices.
+  - Session policies: Idle timeout, concurrent session limits, geo-fencing.
+  - Audit logs: Filter by actor, action, resource. Export to CSV.
+- **Notifications**
+  - Global defaults per channel (Email, Push, SMS, In-App). Allow per-community overrides.
+  - Digest frequency settings, quiet hours, escalation paths.
+- **Integrations**
+  - Configure webhooks, Zapier, Slack, Stripe, Zoom. Provide test connection.
+  - API keys management with scopes, expiration, IP restrictions.
+
+## 4. Data Entry Validation & Error Handling
+- **Form validations**: Inline + summary, regex checks, conditional logic (if monetization enabled → require Stripe account).
+- **Error states**: Provide descriptive messages, recovery options, support link.
+- **Autosave & versioning**: Save history, allow revert to prior version. Display timeline of changes with author.
+
+## 5. Documentation & Review
+- **Design specs**: Maintain Figma design kit with dev-ready redlines. Each component includes margin/padding, states, responsive notes.
+- **Storybook/Widgetbook**: Document all screens with controls for states.
+- **QA checklists**: Page-level checklists covering layout, accessibility, data, performance.
+- **Release notes**: Log changes per module in `docs/release/page-designs.md`.
+


### PR DESCRIPTION
## Summary
- add a detailed styling and UX organization guide covering current baselines and upgraded visions for web and mobile surfaces
- document page, screen, and admin control designs alongside branding systems and asset governance updates
- define dummy content management workflows including seeding, rotation, permissions, and mobile demo integrations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf6c361d083209e842daa5dedde57