### PR TITLE
Align Flutter mobile build tooling with current SDK requirements

### DIFF
--- a/Academy/Student Mobile APP/academy_lms_app/android/app/build.gradle
+++ b/Academy/Student Mobile APP/academy_lms_app/android/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -30,16 +30,16 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace "com.example.academy_lms_app"
-    compileSdkVersion 34
+    compileSdk 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {

--- a/Academy/Student Mobile APP/academy_lms_app/android/build.gradle
+++ b/Academy/Student Mobile APP/academy_lms_app/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.9.20'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:8.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/Academy/Student Mobile APP/academy_lms_app/android/settings.gradle
+++ b/Academy/Student Mobile APP/academy_lms_app/android/settings.gradle
@@ -18,12 +18,15 @@ pluginManagement {
 
     plugins {
         id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+        id "com.android.application" version "8.2.1" apply false
+        id "org.jetbrains.kotlin.android" version "1.9.22" apply false
     }
 }
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.4.0" apply false
+    id "com.android.application" apply false
+    id "org.jetbrains.kotlin.android" apply false
 }
 
 include ":app"

--- a/Academy/Student Mobile APP/academy_lms_app/ios/Podfile
+++ b/Academy/Student Mobile APP/academy_lms_app/ios/Podfile
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+platform :ios, '12.0'
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. Run 'flutter pub get' or 'flutter build ios' to generate it."
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT=(.*)/)
+    return matches[1].strip unless matches.nil?
+  end
+  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Please ensure the Flutter SDK is installed.'
+end
+
+require File.expand_path(File.join(flutter_root, 'packages', 'flutter_tools', 'bin', 'podhelper'))
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks! :linkage => :static
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+target 'RunnerTests' do
+  inherit! :search_paths
+end
+
+post_install do |installer|
+  flutter_post_install(installer)
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end


### PR DESCRIPTION
## Summary
- bump the Android Gradle plugin and Kotlin tooling versions to match the Gradle 8 wrapper
- update the app module to use the new Kotlin plugin ID and Java 17 compile target
- add a canonical Flutter Podfile so iOS builds have the required CocoaPods configuration

## Testing
- Not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc9ce337e483209a7871c79577a68f