### PR TITLE
Implement data protection retention jobs and mobile wipe policies

### DIFF
--- a/Academy/Student Mobile APP/academy_lms_app/lib/config/data_protection.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/config/data_protection.dart
@@ -1,0 +1,56 @@
+class DataProtectionConfiguration {
+  DataProtectionConfiguration._({
+    required this.personalDataRetentionDays,
+    required this.secureWipeOnLogout,
+    required this.legacySensitiveKeys,
+  });
+
+  DataProtectionConfiguration._internal()
+      : this._(
+          personalDataRetentionDays: const int.fromEnvironment(
+            'ACADEMY_MOBILE_PERSONAL_DATA_RETENTION_DAYS',
+            defaultValue: 30,
+          ),
+          secureWipeOnLogout: const bool.fromEnvironment(
+            'ACADEMY_MOBILE_SECURE_WIPE_ON_LOGOUT',
+            defaultValue: true,
+          ),
+          legacySensitiveKeys: _parseLegacyKeys(
+            const String.fromEnvironment(
+              'ACADEMY_MOBILE_LEGACY_SENSITIVE_KEYS',
+              defaultValue:
+                  'password,user,password_confirmation,user_name,user_photo,school_name,email',
+            ),
+          ),
+        );
+
+  static final DataProtectionConfiguration instance =
+      DataProtectionConfiguration._internal();
+
+  final int personalDataRetentionDays;
+  final bool secureWipeOnLogout;
+  final List<String> legacySensitiveKeys;
+
+  factory DataProtectionConfiguration.override({
+    required int personalDataRetentionDays,
+    required bool secureWipeOnLogout,
+    List<String>? legacySensitiveKeys,
+  }) {
+    return DataProtectionConfiguration._(
+      personalDataRetentionDays: personalDataRetentionDays,
+      secureWipeOnLogout: secureWipeOnLogout,
+      legacySensitiveKeys: _normaliseKeys(legacySensitiveKeys ?? const <String>[]),
+    );
+  }
+
+  static List<String> _parseLegacyKeys(String raw) {
+    return _normaliseKeys(raw.split(','));
+  }
+
+  static List<String> _normaliseKeys(Iterable<String> keys) {
+    return keys
+        .map((key) => key.trim())
+        .where((key) => key.isNotEmpty)
+        .toList(growable: false);
+  }
+}

--- a/Academy/Student Mobile APP/academy_lms_app/lib/main.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/main.dart
@@ -34,6 +34,7 @@ import 'services/observability/mobile_observability_client.dart';
 import 'services/migration/migration_plan_service.dart';
 import 'services/migration/migration_runbook_service.dart';
 import 'services/security/auth_session_manager.dart';
+import 'services/security/data_protection_service.dart';
 import 'l10n/app_localizations.dart';
 
 final GlobalKey<NavigatorState> appNavigatorKey = GlobalKey<NavigatorState>();
@@ -53,6 +54,7 @@ Future<void> main() async {
   telemetry.environment = configuration.environment;
 
   final sessionManager = AuthSessionManager.instance;
+  await DataProtectionService.instance.enforcePolicies();
   final observabilityClient = MobileObservabilityClient.instance;
   observabilityClient.configure(
     configuration: configuration,

--- a/Academy/Student Mobile APP/academy_lms_app/lib/providers/shared_pref_helper.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/providers/shared_pref_helper.dart
@@ -2,6 +2,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/security/auth_session_manager.dart';
+import '../services/security/data_protection_service.dart';
 import '../services/security/secure_credential_store.dart';
 
 class SharedPreferenceHelper {
@@ -36,7 +37,12 @@ class SharedPreferenceHelper {
 
   Future<bool> setUserImage(String image) async {
     final pref = await SharedPreferences.getInstance();
-    return pref.setString(userPref.Image.toString(), image);
+    final stored = await pref.setString(userPref.Image.toString(), image);
+    if (stored) {
+      await DataProtectionService.instance
+          .registerPersonalDataKey(userPref.Image.toString());
+    }
+    return stored;
   }
 
   Future<String?> getUserImage() async {

--- a/Academy/Student Mobile APP/academy_lms_app/lib/screens/login.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/screens/login.dart
@@ -11,6 +11,7 @@ import 'package:academy_lms_app/screens/tab_screen.dart';
 import 'package:academy_lms_app/services/security/auth_session.dart';
 import 'package:academy_lms_app/services/security/auth_session_manager.dart';
 import 'package:academy_lms_app/services/security/device_identity_provider.dart';
+import 'package:academy_lms_app/services/security/data_protection_service.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:http/http.dart' as http;
@@ -336,9 +337,22 @@ class _LoginScreenState extends State<LoginScreen> {
 
     sharedPreferences ??= await SharedPreferences.getInstance();
 
-    sharedPreferences!.setString('user', jsonEncode(user));
-    sharedPreferences!.setString('email', _emailController.text.trim());
-    sharedPreferences!.setString('password', _passwordController.text);
+    final storedUser =
+        await sharedPreferences!.setString('user', jsonEncode(user));
+    final storedEmail = await sharedPreferences!
+        .setString('email', _emailController.text.trim());
+
+    final trackedKeys = <String>[];
+    if (storedUser) {
+      trackedKeys.add('user');
+    }
+    if (storedEmail) {
+      trackedKeys.add('email');
+    }
+    if (trackedKeys.isNotEmpty) {
+      await DataProtectionService.instance
+          .registerPersonalDataKeys(trackedKeys);
+    }
 
     token = await AuthSessionManager.instance.getValidAccessToken();
     await Provider.of<Auth>(context, listen: false).synchronizeToken();

--- a/Academy/Student Mobile APP/academy_lms_app/lib/services/security/data_protection_service.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/lib/services/security/data_protection_service.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../config/data_protection.dart';
+import 'secure_credential_store.dart';
+
+typedef CredentialWiper = Future<void> Function();
+
+class DataProtectionService {
+  DataProtectionService._internal({
+    DataProtectionConfiguration? configuration,
+    SharedPreferences? preferences,
+    CredentialWiper? credentialWiper,
+    DateTime Function()? clock,
+  })  : _configuration = configuration ?? DataProtectionConfiguration.instance,
+        _preferences = preferences,
+        _credentialWiper = credentialWiper,
+        _clock = clock ?? DateTime.now;
+
+  DataProtectionService.test({
+    required DataProtectionConfiguration configuration,
+    required SharedPreferences preferences,
+    CredentialWiper? credentialWiper,
+    DateTime Function()? clock,
+  })  : _configuration = configuration,
+        _preferences = preferences,
+        _credentialWiper = credentialWiper,
+        _clock = clock ?? DateTime.now;
+
+  static final DataProtectionService instance = DataProtectionService._internal();
+
+  final DataProtectionConfiguration _configuration;
+  SharedPreferences? _preferences;
+  final CredentialWiper? _credentialWiper;
+  final DateTime Function() _clock;
+
+  static const String _trackedKeysKey = 'data_protection.tracked_keys';
+  static const String _lastEnforcedKey = 'data_protection.last_enforced_at';
+
+  bool get secureWipeEnabled => _configuration.secureWipeOnLogout;
+
+  Future<void> enforcePolicies() async {
+    final prefs = await _ensurePrefs();
+    final tracked = _loadTrackedKeys(prefs);
+    final now = _clock().toUtc();
+
+    final retentionDays = _configuration.personalDataRetentionDays;
+    if (retentionDays <= 0 && tracked.isNotEmpty) {
+      await _removeTrackedKeys(prefs, tracked.keys);
+      tracked.clear();
+    } else if (retentionDays > 0) {
+      final cutoff = now.subtract(Duration(days: retentionDays));
+      final keysToRemove = tracked.entries
+          .where((entry) => entry.value.isBefore(cutoff))
+          .map((entry) => entry.key)
+          .toList(growable: false);
+
+      if (keysToRemove.isNotEmpty) {
+        await _removeTrackedKeys(prefs, keysToRemove);
+        tracked.removeWhere((key, storedAt) => keysToRemove.contains(key));
+      }
+    }
+
+    await _removeLegacySensitiveKeys(prefs);
+    await _persistTrackedKeys(prefs, tracked);
+    await prefs.setString(_lastEnforcedKey, now.toIso8601String());
+  }
+
+  Future<void> registerPersonalDataKey(String key) async {
+    if (key.isEmpty) {
+      return;
+    }
+
+    final prefs = await _ensurePrefs();
+    final tracked = _loadTrackedKeys(prefs);
+    tracked[key] = _clock().toUtc();
+    await _persistTrackedKeys(prefs, tracked);
+  }
+
+  Future<void> registerPersonalDataKeys(Iterable<String> keys) async {
+    final filtered = keys.where((key) => key.isNotEmpty).toList(growable: false);
+    if (filtered.isEmpty) {
+      return;
+    }
+
+    final prefs = await _ensurePrefs();
+    final tracked = _loadTrackedKeys(prefs);
+    final timestamp = _clock().toUtc();
+    for (final key in filtered) {
+      tracked[key] = timestamp;
+    }
+    await _persistTrackedKeys(prefs, tracked);
+  }
+
+  Future<void> wipeLocalFootprint() async {
+    final prefs = await _ensurePrefs();
+    final tracked = _loadTrackedKeys(prefs);
+
+    if (tracked.isNotEmpty) {
+      await _removeTrackedKeys(prefs, tracked.keys);
+    }
+
+    await _removeLegacySensitiveKeys(prefs);
+    await _persistTrackedKeys(prefs, {});
+    await prefs.remove(_lastEnforcedKey);
+
+    if (_configuration.secureWipeOnLogout) {
+      final wiper =
+          _credentialWiper ?? () => SecureCredentialStore.instance.clearAll();
+      await wiper();
+    }
+  }
+
+  Future<SharedPreferences> _ensurePrefs() async {
+    _preferences ??= await SharedPreferences.getInstance();
+    return _preferences!;
+  }
+
+  Map<String, DateTime> _loadTrackedKeys(SharedPreferences prefs) {
+    final raw = prefs.getString(_trackedKeysKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, DateTime>{};
+    }
+
+    try {
+      final Map<String, dynamic> decoded = jsonDecode(raw) as Map<String, dynamic>;
+      final entries = <String, DateTime>{};
+      decoded.forEach((key, value) {
+        if (value is String) {
+          final parsed = DateTime.tryParse(value);
+          if (parsed != null) {
+            entries[key] = parsed.toUtc();
+          }
+        }
+      });
+      return entries;
+    } catch (_) {
+      return <String, DateTime>{};
+    }
+  }
+
+  Future<void> _persistTrackedKeys(
+    SharedPreferences prefs,
+    Map<String, DateTime> tracked,
+  ) async {
+    if (tracked.isEmpty) {
+      await prefs.remove(_trackedKeysKey);
+      return;
+    }
+
+    final payload = <String, String>{};
+    tracked.forEach((key, storedAt) {
+      payload[key] = storedAt.toUtc().toIso8601String();
+    });
+
+    await prefs.setString(_trackedKeysKey, jsonEncode(payload));
+  }
+
+  Future<void> _removeTrackedKeys(SharedPreferences prefs, Iterable<String> keys) async {
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
+
+  Future<void> _removeLegacySensitiveKeys(SharedPreferences prefs) async {
+    for (final key in _configuration.legacySensitiveKeys) {
+      if (prefs.containsKey(key)) {
+        await prefs.remove(key);
+      }
+    }
+  }
+}

--- a/Academy/Student Mobile APP/academy_lms_app/test/services/security/data_protection_service_test.dart
+++ b/Academy/Student Mobile APP/academy_lms_app/test/services/security/data_protection_service_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:academy_lms_app/config/data_protection.dart';
+import 'package:academy_lms_app/services/security/data_protection_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('enforcePolicies prunes expired entries and keeps active ones', () async {
+    final prefs = await SharedPreferences.getInstance();
+    var now = DateTime.utc(2024, 1, 1, 12);
+
+    final service = DataProtectionService.test(
+      configuration: DataProtectionConfiguration.override(
+        personalDataRetentionDays: 30,
+        secureWipeOnLogout: true,
+        legacySensitiveKeys: ['password'],
+      ),
+      preferences: prefs,
+      credentialWiper: () async {},
+      clock: () => now,
+    );
+
+    await prefs.setString('stale', 'value');
+    await service.registerPersonalDataKey('stale');
+
+    now = now.add(const Duration(days: 45));
+    await prefs.setString('fresh', 'value');
+    await service.registerPersonalDataKey('fresh');
+
+    await prefs.setString('password', 'legacy');
+
+    await service.enforcePolicies();
+
+    expect(prefs.containsKey('stale'), isFalse);
+    expect(prefs.containsKey('fresh'), isTrue);
+    expect(prefs.containsKey('password'), isFalse);
+
+    final trackedRaw = prefs.getString('data_protection.tracked_keys');
+    expect(trackedRaw, isNotNull);
+    final tracked = Map<String, dynamic>.from(jsonDecode(trackedRaw!));
+    expect(tracked.keys, contains('fresh'));
+    expect(tracked.keys, isNot(contains('stale')));
+  });
+
+  test('wipeLocalFootprint clears tracked data and honours secure wipe flag', () async {
+    bool wipeCalled = false;
+    final prefs = await SharedPreferences.getInstance();
+    final configuration = DataProtectionConfiguration.override(
+      personalDataRetentionDays: 30,
+      secureWipeOnLogout: true,
+      legacySensitiveKeys: const [],
+    );
+
+    final service = DataProtectionService.test(
+      configuration: configuration,
+      preferences: prefs,
+      credentialWiper: () async {
+        wipeCalled = true;
+      },
+      clock: () => DateTime.utc(2024, 1, 1),
+    );
+
+    await prefs.setString('user', 'value');
+    await service.registerPersonalDataKey('user');
+
+    await service.wipeLocalFootprint();
+
+    expect(prefs.containsKey('user'), isFalse);
+    expect(prefs.getString('data_protection.tracked_keys'), isNull);
+    expect(wipeCalled, isTrue);
+
+    SharedPreferences.setMockInitialValues({});
+    wipeCalled = false;
+    final prefsDisabled = await SharedPreferences.getInstance();
+    final disabledService = DataProtectionService.test(
+      configuration: DataProtectionConfiguration.override(
+        personalDataRetentionDays: 30,
+        secureWipeOnLogout: false,
+        legacySensitiveKeys: const [],
+      ),
+      preferences: prefsDisabled,
+      credentialWiper: () async {
+        wipeCalled = true;
+      },
+      clock: () => DateTime.utc(2024, 1, 1),
+    );
+
+    await prefsDisabled.setString('user', 'value');
+    await disabledService.registerPersonalDataKey('user');
+
+    await disabledService.wipeLocalFootprint();
+
+    expect(prefsDisabled.containsKey('user'), isFalse);
+    expect(wipeCalled, isFalse);
+  });
+}

--- a/Academy/Web_Application/Academy-LMS/app/Console/Commands/Compliance/PrunePersonalData.php
+++ b/Academy/Web_Application/Academy-LMS/app/Console/Commands/Compliance/PrunePersonalData.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands\Compliance;
+
+use App\Services\Security\DataRetentionService;
+use Illuminate\Console\Command;
+
+class PrunePersonalData extends Command
+{
+    protected $signature = 'compliance:prune-personal-data {--dry-run : Only report rows that would be deleted}';
+
+    protected $description = 'Apply data protection retention policies for audit logs, device sessions, and personal access tokens.';
+
+    public function handle(DataRetentionService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if (! $dryRun && $this->shouldRunBackup()) {
+            $profile = config('security.data_protection.backup.profile', 'media');
+            $this->info("Running backup profile [{$profile}] before pruning sensitive data...");
+            $this->call('storage:backup', ['profile' => $profile]);
+        }
+
+        $results = $service->prune($dryRun);
+
+        $this->components->twoColumnDetail('Audit logs pruned', (string) $results['audit_logs_deleted']);
+        $this->components->twoColumnDetail('Device sessions removed', (string) $results['device_sessions_deleted']);
+        $this->components->twoColumnDetail('Device access tokens removed', (string) $results['device_tokens_deleted']);
+        $this->components->twoColumnDetail('Personal access tokens removed', (string) $results['personal_access_tokens_deleted']);
+
+        if ($dryRun) {
+            $this->comment('Dry run complete. No records were deleted.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Data protection pruning finished successfully.');
+
+        return self::SUCCESS;
+    }
+
+    private function shouldRunBackup(): bool
+    {
+        if (! config('security.data_protection.backup.enabled', false)) {
+            return false;
+        }
+
+        return config('app.env') !== 'testing';
+    }
+}

--- a/Academy/Web_Application/Academy-LMS/app/Console/Kernel.php
+++ b/Academy/Web_Application/Academy-LMS/app/Console/Kernel.php
@@ -103,6 +103,13 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping()
             ->runInBackground();
 
+        $schedule->command('compliance:prune-personal-data')
+            ->dailyAt(config('security.data_protection.prune_schedule', '03:15'))
+            ->environments(['staging', 'production'])
+            ->onOneServer()
+            ->withoutOverlapping()
+            ->runInBackground();
+
         foreach (config('storage_lifecycle.profiles', []) as $profile => $settings) {
             $backup = $settings['backup'] ?? null;
             if (! is_array($backup) || empty($backup['enabled'])) {

--- a/Academy/Web_Application/Academy-LMS/app/Models/AuditLog.php
+++ b/Academy/Web_Application/Academy-LMS/app/Models/AuditLog.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\EncryptedAttribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -22,7 +23,9 @@ class AuditLog extends Model
     ];
 
     protected $casts = [
-        'metadata' => 'array',
+        'ip_address' => EncryptedAttribute::class,
+        'user_agent' => EncryptedAttribute::class,
+        'metadata' => EncryptedAttribute::class,
         'performed_at' => 'datetime',
     ];
 

--- a/Academy/Web_Application/Academy-LMS/app/Models/DeviceIp.php
+++ b/Academy/Web_Application/Academy-LMS/app/Models/DeviceIp.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\EncryptedAttribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -26,10 +27,16 @@ class DeviceIp extends Model
     ];
 
     protected $casts = [
+        'ip_address' => EncryptedAttribute::class,
+        'session_id' => EncryptedAttribute::class,
+        'device_name' => EncryptedAttribute::class,
+        'platform' => EncryptedAttribute::class,
+        'app_version' => EncryptedAttribute::class,
+        'label' => EncryptedAttribute::class,
         'trusted_at' => 'datetime',
         'revoked_at' => 'datetime',
         'last_seen_at' => 'datetime',
-        'last_headers' => 'array',
+        'last_headers' => EncryptedAttribute::class,
     ];
 
     public function tokens(): HasMany

--- a/Academy/Web_Application/Academy-LMS/app/Models/OfflinePayment.php
+++ b/Academy/Web_Application/Academy-LMS/app/Models/OfflinePayment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\EncryptedAttribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -20,5 +21,11 @@ class OfflinePayment extends Model
         'bank_no',
         'doc',
         'status',
+    ];
+
+    protected $casts = [
+        'items' => EncryptedAttribute::class,
+        'phone_no' => EncryptedAttribute::class,
+        'bank_no' => EncryptedAttribute::class,
     ];
 }

--- a/Academy/Web_Application/Academy-LMS/app/Services/Security/DataRetentionService.php
+++ b/Academy/Web_Application/Academy-LMS/app/Services/Security/DataRetentionService.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Services\Security;
+
+use App\Models\AuditLog;
+use App\Models\DeviceAccessToken;
+use App\Models\DeviceIp;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class DataRetentionService
+{
+    public function __construct(private readonly Repository $config)
+    {
+    }
+
+    /**
+     * Prune sensitive data stores according to configured retention policies.
+     *
+     * @return array<string, int>
+     */
+    public function prune(bool $dryRun = false): array
+    {
+        $results = [
+            'audit_logs_deleted' => 0,
+            'device_sessions_deleted' => 0,
+            'device_tokens_deleted' => 0,
+            'personal_access_tokens_deleted' => 0,
+        ];
+
+        $results['audit_logs_deleted'] = $this->pruneAuditLogs($dryRun);
+
+        $deviceResult = $this->pruneDeviceSessions($dryRun);
+        $results['device_sessions_deleted'] = $deviceResult['device_sessions_deleted'];
+        $results['device_tokens_deleted'] = $deviceResult['device_tokens_deleted'];
+        $results['personal_access_tokens_deleted'] += $deviceResult['personal_access_tokens_deleted'];
+
+        $results['personal_access_tokens_deleted'] += $this->pruneStandaloneTokens(
+            $dryRun,
+            $deviceResult['personal_access_tokens_retained']
+        );
+
+        return $results;
+    }
+
+    private function pruneAuditLogs(bool $dryRun): int
+    {
+        $retentionDays = (int) $this->config->get('security.data_protection.audit_logs.retention_days', 3650);
+        if ($retentionDays <= 0) {
+            return 0;
+        }
+
+        $cutoff = CarbonImmutable::now()->subDays($retentionDays);
+
+        $query = AuditLog::query()->where('performed_at', '<', $cutoff);
+
+        if ($dryRun) {
+            return (int) $query->count();
+        }
+
+        return (int) $query->delete();
+    }
+
+    /**
+     * @return array{device_sessions_deleted: int, device_tokens_deleted: int, personal_access_tokens_deleted: int, personal_access_tokens_retained: array<int>}
+     */
+    private function pruneDeviceSessions(bool $dryRun): array
+    {
+        $retentionDays = (int) $this->config->get('security.data_protection.device_sessions.retention_days', 180);
+        if ($retentionDays <= 0) {
+            return [
+                'device_sessions_deleted' => 0,
+                'device_tokens_deleted' => 0,
+                'personal_access_tokens_deleted' => 0,
+                'personal_access_tokens_retained' => [],
+            ];
+        }
+
+        $cutoff = CarbonImmutable::now()->subDays($retentionDays);
+
+        $devices = DeviceIp::query()
+            ->where(function ($query) use ($cutoff) {
+                $query->whereNotNull('revoked_at')
+                    ->where('revoked_at', '<', $cutoff);
+            })
+            ->orWhere(function ($query) use ($cutoff) {
+                $query->whereNull('revoked_at')
+                    ->where(function ($inner) use ($cutoff) {
+                        $inner->whereNull('last_seen_at')
+                            ->orWhere('last_seen_at', '<', $cutoff);
+                    });
+            })
+            ->get(['id']);
+
+        if ($devices->isEmpty()) {
+            return [
+                'device_sessions_deleted' => 0,
+                'device_tokens_deleted' => 0,
+                'personal_access_tokens_deleted' => 0,
+                'personal_access_tokens_retained' => [],
+            ];
+        }
+
+        $deviceIds = $devices->pluck('id')->all();
+
+        $deviceTokens = DeviceAccessToken::query()
+            ->with('token')
+            ->whereIn('device_ip_id', $deviceIds)
+            ->get();
+
+        $tokenIds = $deviceTokens
+            ->pluck('token_id')
+            ->filter()
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values();
+
+        if ($dryRun) {
+            return [
+                'device_sessions_deleted' => count($deviceIds),
+                'device_tokens_deleted' => $deviceTokens->count(),
+                'personal_access_tokens_deleted' => $tokenIds->count(),
+                'personal_access_tokens_retained' => $tokenIds->all(),
+            ];
+        }
+
+        $personalTokensDeleted = 0;
+        $deviceTokensDeleted = 0;
+
+        DB::transaction(function () use (
+            $deviceIds,
+            $tokenIds,
+            $deviceTokens,
+            &$personalTokensDeleted,
+            &$deviceTokensDeleted
+        ) {
+            if ($tokenIds->isNotEmpty()) {
+                $personalTokensDeleted = PersonalAccessToken::query()
+                    ->whereIn('id', $tokenIds->all())
+                    ->delete();
+            }
+
+            if ($deviceTokens->isNotEmpty()) {
+                $deviceTokensDeleted = DeviceAccessToken::query()
+                    ->whereIn('id', $deviceTokens->pluck('id')->all())
+                    ->delete();
+            }
+
+            DeviceIp::query()->whereIn('id', $deviceIds)->delete();
+        });
+
+        return [
+            'device_sessions_deleted' => count($deviceIds),
+            'device_tokens_deleted' => $deviceTokensDeleted,
+            'personal_access_tokens_deleted' => $personalTokensDeleted,
+            'personal_access_tokens_retained' => [],
+        ];
+    }
+
+    private function pruneStandaloneTokens(bool $dryRun, array $excludedTokenIds): int
+    {
+        $retentionDays = (int) $this->config->get('security.data_protection.personal_access_tokens.retention_days', 90);
+        if ($retentionDays <= 0) {
+            return 0;
+        }
+
+        $cutoff = CarbonImmutable::now()->subDays($retentionDays);
+
+        $query = PersonalAccessToken::query()
+            ->where(function ($inner) use ($cutoff) {
+                $inner->whereNull('last_used_at')
+                    ->where('created_at', '<', $cutoff);
+            })
+            ->orWhere(function ($inner) use ($cutoff) {
+                $inner->whereNotNull('last_used_at')
+                    ->where('last_used_at', '<', $cutoff);
+            });
+
+        if (! empty($excludedTokenIds)) {
+            $query->whereNotIn('id', $excludedTokenIds);
+        }
+
+        if ($dryRun) {
+            return (int) $query->count();
+        }
+
+        return (int) $query->delete();
+    }
+}

--- a/Academy/Web_Application/Academy-LMS/config/security.php
+++ b/Academy/Web_Application/Academy-LMS/config/security.php
@@ -34,4 +34,21 @@ return [
     'sessions' => [
         'max_parallel_tokens' => env('SESSION_MAX_PARALLEL_TOKENS', 10),
     ],
+
+    'data_protection' => [
+        'prune_schedule' => env('DATA_PROTECTION_PRUNE_SCHEDULE', '03:15'),
+        'audit_logs' => [
+            'retention_days' => (int) env('DATA_PROTECTION_AUDIT_LOG_RETENTION_DAYS', 3650),
+        ],
+        'device_sessions' => [
+            'retention_days' => (int) env('DATA_PROTECTION_DEVICE_SESSION_RETENTION_DAYS', 180),
+        ],
+        'personal_access_tokens' => [
+            'retention_days' => (int) env('DATA_PROTECTION_TOKEN_RETENTION_DAYS', 90),
+        ],
+        'backup' => [
+            'enabled' => (bool) env('DATA_PROTECTION_BACKUP_ENABLED', false),
+            'profile' => env('DATA_PROTECTION_BACKUP_PROFILE', 'media'),
+        ],
+    ],
 ];

--- a/Academy/Web_Application/Academy-LMS/tests/Feature/Console/PrunePersonalDataCommandTest.php
+++ b/Academy/Web_Application/Academy-LMS/tests/Feature/Console/PrunePersonalDataCommandTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\AuditLog;
+use App\Models\DeviceAccessToken;
+use App\Models\DeviceIp;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\PersonalAccessToken;
+use Tests\TestCase;
+
+class PrunePersonalDataCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_prunes_records_past_retention_thresholds(): void
+    {
+        $this->configureRetention();
+
+        $user = User::factory()->create();
+
+        $oldDevice = DeviceIp::create([
+            'user_id' => $user->id,
+            'user_agent' => 'legacy-device',
+            'ip_address' => '192.0.2.10',
+            'last_seen_at' => now()->subDays(200),
+            'revoked_at' => now()->subDays(120),
+        ]);
+
+        $oldAccessToken = $user->createToken('device:legacy');
+        DeviceAccessToken::create([
+            'device_ip_id' => $oldDevice->id,
+            'token_id' => $oldAccessToken->accessToken->id,
+            'last_used_at' => now()->subDays(120),
+        ]);
+        PersonalAccessToken::query()->whereKey($oldAccessToken->accessToken->id)->update([
+            'created_at' => now()->subDays(200),
+            'updated_at' => now()->subDays(120),
+            'last_used_at' => now()->subDays(120),
+        ]);
+
+        $recentDevice = DeviceIp::create([
+            'user_id' => $user->id,
+            'user_agent' => 'recent-device',
+            'ip_address' => '198.51.100.5',
+            'last_seen_at' => now()->subDays(5),
+        ]);
+        $recentAccessToken = $user->createToken('device:recent');
+        DeviceAccessToken::create([
+            'device_ip_id' => $recentDevice->id,
+            'token_id' => $recentAccessToken->accessToken->id,
+            'last_used_at' => now()->subDay(),
+        ]);
+
+        $staleToken = PersonalAccessToken::forceCreate([
+            'tokenable_type' => User::class,
+            'tokenable_id' => $user->id,
+            'name' => 'legacy',
+            'token' => hash('sha256', (string) Str::uuid()),
+            'abilities' => ['*'],
+            'last_used_at' => now()->subDays(120),
+            'created_at' => now()->subDays(200),
+            'updated_at' => now()->subDays(120),
+        ]);
+
+        $oldAudit = AuditLog::create([
+            'user_id' => $user->id,
+            'actor_role' => 'admin',
+            'action' => 'user.delete',
+            'ip_address' => '203.0.113.9',
+            'user_agent' => 'Test',
+            'metadata' => ['reason' => 'cleanup'],
+            'performed_at' => now()->subDays(400),
+        ]);
+        $recentAudit = AuditLog::create([
+            'user_id' => $user->id,
+            'actor_role' => 'admin',
+            'action' => 'user.update',
+            'ip_address' => '203.0.113.10',
+            'user_agent' => 'Test',
+            'metadata' => ['reason' => 'update'],
+            'performed_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('compliance:prune-personal-data')
+            ->expectsOutputToContain('Audit logs pruned')
+            ->expectsOutputToContain('Data protection pruning finished successfully.')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseMissing('audit_logs', ['id' => $oldAudit->id]);
+        $this->assertDatabaseHas('audit_logs', ['id' => $recentAudit->id]);
+
+        $this->assertDatabaseMissing('device_ips', ['id' => $oldDevice->id]);
+        $this->assertDatabaseHas('device_ips', ['id' => $recentDevice->id]);
+
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $oldAccessToken->accessToken->id]);
+        $this->assertDatabaseHas('personal_access_tokens', ['id' => $recentAccessToken->accessToken->id]);
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $staleToken->id]);
+    }
+
+    public function test_dry_run_reports_without_deleting(): void
+    {
+        $this->configureRetention();
+
+        $user = User::factory()->create();
+
+        $device = DeviceIp::create([
+            'user_id' => $user->id,
+            'user_agent' => 'dry-run-device',
+            'ip_address' => '192.0.2.30',
+            'last_seen_at' => now()->subDays(200),
+            'revoked_at' => now()->subDays(120),
+        ]);
+
+        $token = $user->createToken('device:dry-run');
+        DeviceAccessToken::create([
+            'device_ip_id' => $device->id,
+            'token_id' => $token->accessToken->id,
+            'last_used_at' => now()->subDays(120),
+        ]);
+        PersonalAccessToken::query()->whereKey($token->accessToken->id)->update([
+            'created_at' => now()->subDays(200),
+            'updated_at' => now()->subDays(120),
+            'last_used_at' => now()->subDays(120),
+        ]);
+
+        $audit = AuditLog::create([
+            'user_id' => $user->id,
+            'actor_role' => 'system',
+            'action' => 'dry-run',
+            'ip_address' => '198.51.100.55',
+            'user_agent' => 'cli',
+            'metadata' => ['note' => 'dry-run'],
+            'performed_at' => now()->subDays(400),
+        ]);
+
+        $this->artisan('compliance:prune-personal-data --dry-run')
+            ->expectsOutputToContain('Audit logs pruned')
+            ->expectsOutputToContain('Dry run complete. No records were deleted.')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('audit_logs', ['id' => $audit->id]);
+        $this->assertDatabaseHas('device_ips', ['id' => $device->id]);
+        $this->assertDatabaseHas('personal_access_tokens', ['id' => $token->accessToken->id]);
+    }
+
+    private function configureRetention(): void
+    {
+        config()->set('security.data_protection.audit_logs.retention_days', 180);
+        config()->set('security.data_protection.device_sessions.retention_days', 90);
+        config()->set('security.data_protection.personal_access_tokens.retention_days', 45);
+        config()->set('security.data_protection.backup.enabled', false);
+    }
+}


### PR DESCRIPTION
## Summary
- add a backend data retention service with a compliance prune command, scheduled execution, and stronger encryption on audit, device, and offline payment records
- extend security configuration and add feature tests covering pruning behaviour
- introduce mobile data protection configuration and service, wiring enforcement into session/auth flows and shared preference helpers with unit tests

## Testing
- php artisan test *(fails: environment lacks database/search dependencies, multiple existing suites error)*
- flutter test *(fails: flutter toolchain unavailable in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0da348c08320ac87983c131578fc