### PR TITLE
Add Mermaid diagrams for current UI layouts

### DIFF
--- a/Academy/docs/ui/mobile_app_screens.mmd
+++ b/Academy/docs/ui/mobile_app_screens.mmd
@@ -1,0 +1,63 @@
+%% Academy Mobile Apps (Flutter) UI Overview
+%% Mermaid flowchart illustrating core screens, widgets and navigation scaffolding
+flowchart TB
+  classDef section fill:#eef6ff,stroke:#1f4b99,stroke-width:1.2,color:#0b1f33;
+
+  subgraph AppShell["Application Shell"]
+    direction TB
+    tabs(["TabsScreen Scaffold\nAppBar with brand logo, IndexedStack body, Convex bottom bar (Home, Communities, My Courses, Cart, Account)"]):::section
+    fab(["Floating Filter Button\nRounded FAB launching course FilterScreen when not on Cart tab"]):::section
+    authSwitch(["Auth-aware Tabs\nUnauthenticated users see LoginScreen placeholders except Home"]):::section
+    tabs --> fab
+    tabs --> authSwitch
+  end
+
+  subgraph HomeScreen["Home Screen"]
+    direction TB
+    refresh(["RefreshIndicator wrapping ScrollView\nBootstraps categories & top courses via Providers"]):::section
+    topSection(["Top Course Header Row\nTitle + 'All courses' CTA navigating to catalog"]):::section
+    courseCarousel(["Horizontal Top Course Cards\nImage, title snippet, rating summary, tap to open CourseDetail"]):::section
+    categoryHeader(["Course Categories Header\nRepeats 'All courses' CTA"]):::section
+    categoryList(["Vertical Category List\nThumbnail, sub-category count, gradient chevron, navigates to CategoryDetails"]):::section
+    refresh --> topSection --> courseCarousel --> categoryHeader --> categoryList
+  end
+
+  subgraph CourseDetail["Course Detail Screen"]
+    direction TB
+    headerActions(["App bar shortcut row\nAccount icon + Buy Now / Checkout buttons depending on purchase state"]):::section
+    overviewTabs({"TabController (3)\nOverview, Curriculum, Reviews rendered inside tab views"}):::section
+    videoPreview(["Preview Player Modal Support\nHandles YouTube, Vimeo, HTML5 and local videos via Plyr widgets"]):::section
+    enrollmentCTA(["Enrollment & Share Utilities\nFree-enroll handler, add/remove cart, share links"]):::section
+    headerActions --> overviewTabs --> videoPreview --> enrollmentCTA
+  end
+
+  subgraph LearningLibrary["My Courses Module"]
+    direction TB
+    myCoursesGrid(["AlignedGridView\nTwo-column card grid populated from MyCourses provider"]):::section
+    progressTiles(["MyCourseGrid Cards\nShow cover image, progress indicators, resume controls (Start/Continue/Watch Again)"]):::section
+    myCoursesGrid --> progressTiles
+  end
+
+  subgraph Commerce["Cart & Checkout"]
+    direction TB
+    cartList(["CartScreen ListView\nCourse tiles with thumbnail, title, rating summary, delete prompt"]):::section
+    totals(["Pricing Summary\nSubtotal & tax formatted by currency position, displays totals"] ):::section
+    checkoutCTA(["Checkout Button\nBuilds auth token, launches external payment URL"]):::section
+    cartList --> totals --> checkoutCTA
+  end
+
+  subgraph AccountSuite["Account & Settings"]
+    direction TB
+    profileHeader(["Profile Card\nCircle avatar, name, phone pulled from SharedPreferences"]):::section
+    quickActions(["Account Action Tiles\nEdit Profile, Wishlists, Migration Runbook, Device Security, Change Password, Delete Account, Logout"] ):::section
+    communityInsights(["Community Contributions\nActivity metrics surfaced via CommunityNotifier refresh"]):::section
+    profileHeader --> quickActions --> communityInsights
+  end
+
+  subgraph Communities["Communities Explorer"]
+    direction TB
+    onboarding(["Onboarding Flow Trigger\nSchedules prompt after auth & bootstrap"] ):::section
+    listView(["Refreshable Community List\nCommunityCard entries with join/leave/open actions & empty state messaging"]):::section
+    errorSnack(["Error Handling\nSnackBar surfaced when CommunityNotifier reports issues"]):::section
+    onboarding --> listView --> errorSnack
+  end

--- a/Academy/docs/ui/web_app_screens.mmd
+++ b/Academy/docs/ui/web_app_screens.mmd
@@ -1,0 +1,52 @@
+%% Academy Web Application UI Overview
+%% Mermaid flowchart capturing key screens and dashboards
+flowchart TB
+  classDef section fill:#fdf6e3,stroke:#657b83,stroke-width:1.2,color:#073642;
+
+  subgraph PublicMarketing["Public Website (Marketing)"]
+    direction TB
+    hero(["Hero Banner Slider\nCTA button to Explore Courses\nFull-width imagery & swiper pagination"]):::section
+    categories{{"Top Categories Grid\n5 icon cards linking to course listings"}}:::section
+    topCourses(["Top Courses Card Row\nLesson count, rating badge, price ribbon & CTA"]):::section
+    counters(("Impact Counters Strip\nStudents · Instructors · Premium & Free courses")):::section
+    instructorCTA(["Become an Instructor CTA\nVideo thumbnail with modal play button & copy"] ):::section
+    faq{{"FAQ Accordion\nCollapsible questions & answers"}}:::section
+    testimonials(["Testimonial Carousel\nLearner photo, quote, timestamp & star rating"]):::section
+    newsletter(["Newsletter Subscription\nIllustrated card with email input & privacy link"]):::section
+    blog(["Latest Blog Highlights\nImage cards with title, excerpt & posted date"] ):::section
+    hero --> categories --> topCourses --> counters --> instructorCTA --> faq --> testimonials --> newsletter --> blog
+  end
+
+  subgraph CourseExperience["Course Catalog & Detail Experience"]
+    direction TB
+    listing(["Courses Index\nBreadcrumb, layout toggle (grid/list), filter sidebar & paginated cards"]):::section
+    details(["Course Detail Hero\nBreadcrumb, title, instructor chip, rating, language, certificate, enrollment & duration stats"]):::section
+    tabs{{"Sticky Tab Menu\nOverview · Curriculum · Details · Instructor · Reviews sections"}}:::section
+    pricing(["Right-hand Pricing Card\nPurchase actions, badges, coupon modal & preview video modal"] ):::section
+    listing --> details --> tabs
+    tabs --> pricing
+  end
+
+  subgraph StudentPortal["Student Portal"]
+    direction TB
+    sidebar(["Profile Sidebar\nAvatar upload, truncated email, navigation links (Courses, Bootcamps, Bookings, Teams, Ebooks, Profile, Wishlist, Messages, Purchase History, Logout) & Become Instructor CTA"]):::section
+    myCourses(["My Courses Grid\nThumbnail, instructor chip, progress bar, expiry badges, smart resume button"] ):::section
+    sidebar --> myCourses
+  end
+
+  subgraph CommerceFlow["Commerce & Checkout"]
+    direction TB
+    cartHeader(["Cart Breadcrumb & Title Section"]):::section
+    cartItems(["Cart Item Rows\nCourse thumbnail, description snippet, pricing (incl. discount/strike-through) & remove action"]):::section
+    paymentSummary(["Payment Summary Card\nSubtotal, discount, tax, coupon entry, gift toggle & Continue to payment button"] ):::section
+    cartHeader --> cartItems --> paymentSummary
+  end
+
+  subgraph AdminDashboard["Admin Dashboard"]
+    direction TB
+    statCards(["Metric Cards\nCounts for courses, lessons, enrollments, students & instructors"]):::section
+    revenueChart(["Admin Revenue Chart\nYear-to-date line chart with link to revenue screen"]):::section
+    courseStatus(["Course Status Widget\nPie chart with legend for Active, Upcoming, Pending, Private, Draft, Inactive"] ):::section
+    payouts(["Pending Withdrawal Table\nInstructor name/email with requested amount"] ):::section
+    statCards --> revenueChart --> courseStatus --> payouts
+  end


### PR DESCRIPTION
## Summary
- add a Mermaid flowchart illustrating the Academy web application marketing, course, student, commerce, and admin screens
- add a Mermaid flowchart capturing the Flutter mobile app shell, learning, commerce, account, and community explorer views

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ddfab59f5c8320a868d17cea95dd08